### PR TITLE
Use composer Docker image for extension installation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,9 +69,12 @@ pipeline {
                     # Copy composer.json as composer.local.json for MediaWiki
                     cp composer.json "${MW_DIR}/composer.local.json"
 
-                    # Install composer dependencies
-                    cd "${MW_DIR}"
-                    composer update --no-dev --optimize-autoloader
+                    # Install composer dependencies using PHP container
+                    docker run --rm \
+                        -v "${MW_DIR}:/app" \
+                        -w /app \
+                        composer:2 \
+                        composer update --no-dev --optimize-autoloader
                 '''
             }
         }


### PR DESCRIPTION
Jenkins doesn't have PHP/composer installed - use the official composer:2 image instead.