### PR TITLE
Enable MultimediaViewer extension

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -78,6 +78,9 @@ wfLoadExtension( 'YouTube' );
 # WikiEditor - enhanced editing toolbar (bundled with MediaWiki)
 wfLoadExtension( 'WikiEditor' );
 
+# MultimediaViewer - modern lightbox for images (bundled with MediaWiki)
+wfLoadExtension( 'MultimediaViewer' );
+
 # MsUpload - drag-and-drop multiple file upload in edit page
 wfLoadExtension( 'MsUpload' );
 $wgMSU_useDragDrop = true;


### PR DESCRIPTION
## Summary

Enables the MultimediaViewer extension - the official MediaWiki lightbox that's bundled with MediaWiki since 1.31 and used on Wikipedia.

## What it does

When users click on image thumbnails (`[[File:...]]`) or gallery images (`<gallery>`), they get a modern, clean lightbox overlay instead of being taken to the file description page.

## Changes

- **1 line added to LocalSettings.php**: `wfLoadExtension( 'MultimediaViewer' );`

That's it. The extension is already bundled with MediaWiki.

## Test plan

- [ ] Click on any image thumbnail on the wiki
- [ ] Should see dark overlay with large image, caption, and controls
- [ ] Arrow keys or clicking arrows should navigate between images in a gallery