### PR TITLE
Add ParserFunctions extension for template conditionals

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -75,6 +75,9 @@ enableSemantics( parse_url($wgServer, PHP_URL_HOST) );
 # YouTube - for embedding YouTube videos
 wfLoadExtension( 'YouTube' );
 
+# ParserFunctions - {{#if:}}, {{#switch:}}, etc. for templates (bundled with MediaWiki)
+wfLoadExtension( 'ParserFunctions' );
+
 # WikiEditor - enhanced editing toolbar (bundled with MediaWiki)
 wfLoadExtension( 'WikiEditor' );
 


### PR DESCRIPTION
## Summary
- Enables the ParserFunctions extension (bundled with MediaWiki)
- Required for `Template:Instrument` which uses `{{#if:}}` for optional field display

## Context
Created `Template:Instrument` for documenting individual instruments with semantic properties. The template uses conditional logic to only show fields that have values provided.

## Test plan
- [ ] Verify Template:Instrument renders correctly on Thompson DWA-A 2056 page
- [ ] Confirm `{{#if:}}` conditionals work (empty fields should not show rows)