### PR TITLE
Use MediaWiki LogException hook for Sentry error capture

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,9 +1,18 @@
-RewriteEngine On
+# Large file uploads (1GB for Blue Railroad video submissions)
+php_value upload_max_filesize 1073741824
+php_value post_max_size 1073741824
+php_value memory_limit 1342177280
+php_value max_execution_time 600
+php_value max_input_time 600
 
-# Block aggressive bots eating bandwidth
-RewriteCond %{HTTP_USER_AGENT} meta-externalagent [NC,OR]
-RewriteCond %{HTTP_USER_AGENT} Amazonbot [NC]
-RewriteRule .* - [F,L]
+# Block aggressive bots eating bandwidth (SetEnvIf works on NFS, RewriteCond doesn't)
+SetEnvIfNoCase User-Agent "meta-externalagent" bad_bot
+SetEnvIfNoCase User-Agent "Amazonbot" bad_bot
+Order Allow,Deny
+Allow from all
+Deny from env=bad_bot
+
+RewriteEngine On
 
 # Short URL rewrite for MediaWiki
 # Maps /wiki/Page_Name to index.php?title=Page_Name

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -135,7 +135,8 @@ $wgMSU_useDragDrop = true;
 $wgMSU_showAutoCat = true;
 $wgMSU_checkAutoCat = true;
 $wgMSU_imgParams = '400px';
-$wgMSU_uploadsize = '100mb';
+$wgMSU_uploadsize = '1024mb';
+$wgMaxUploadSize = 1024 * 1024 * 1024;  // 1GB in bytes
 
 # TimedMediaHandler - video/audio playback with transcoding
 wfLoadExtension( 'TimedMediaHandler' );


### PR DESCRIPTION
## Problem

DBQueryError and other exceptions caught internally by MediaWiki weren't being reported to Sentry/GlitchTip. The previous approach used PHP's `set_exception_handler()`, but MediaWiki catches these exceptions and handles them internally, never letting them bubble up.

## Solution

Use MediaWiki's `LogException` hook instead. This hook is called by `MWExceptionHandler` for ALL exceptions, including ones MediaWiki catches and handles internally.

## Changes

- Removed: `set_exception_handler`, `set_error_handler` 
- Added: `$wgHooks['LogException']` handler
- Kept: `register_shutdown_function` for fatal errors that bypass exception handling

## References

- [MWExceptionHandler docs](https://doc.wikimedia.org/mediawiki-core/master/php/classMWExceptionHandler.html)
- [LogException hook category](https://www.mediawiki.org/wiki/Category:MediaWiki_hooks_included_in_MWExceptionHandler.php)