### PR TITLE
Add ReleaseDraft namespace for album draft management

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -136,6 +136,9 @@ $wgGroupPermissions['release']['edit'] = true;
 $wgNamespaceProtection[3004] = ['release-edit'];
 $wgGroupPermissions['release']['release-edit'] = true;
 
+# Restrict ReleaseDraft namespace (3006) to users with upload-to-delivery-kid permission
+$wgNamespaceProtection[3006] = ['upload-to-delivery-kid'];
+
 # Make release-edit available as a BotPasswords grant
 $wgGrantPermissions['release-edit']['release-edit'] = true;
 $wgGrantPermissionGroups['release-edit'] = 'other';
@@ -150,8 +153,9 @@ enableSemantics( parse_url($wgServer, PHP_URL_HOST) );
 $smwgNamespacesWithSemanticLinks[NS_CRYPTOGRASS] = true;
 
 # Enable semantic links for Release namespace (after PickiPediaReleases is loaded)
-# Note: NS_RELEASE (3004) is defined by the PickiPediaReleases extension
+# Note: NS_RELEASE (3004) and NS_RELEASEDRAFT (3006) are defined by PickiPediaReleases
 $smwgNamespacesWithSemanticLinks[3004] = true;
+$smwgNamespacesWithSemanticLinks[3006] = true;
 
 # Page Forms - create forms for SMW data entry (installed via Composer)
 wfLoadExtension( 'PageForms' );

--- a/extensions/PickiPediaReleases/extension.json
+++ b/extensions/PickiPediaReleases/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "PickiPediaReleases",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"author": ["CryptoGrass", "Magent"],
 	"url": "https://github.com/cryptograss/pickipedia",
 	"descriptionmsg": "pickipediareleases-desc",
@@ -23,10 +23,22 @@
 			"id": 3005,
 			"constant": "NS_RELEASE_TALK",
 			"name": "Release_talk"
+		},
+		{
+			"id": 3006,
+			"constant": "NS_RELEASEDRAFT",
+			"name": "ReleaseDraft",
+			"defaultcontentmodel": "release-draft-yaml"
+		},
+		{
+			"id": 3007,
+			"constant": "NS_RELEASEDRAFT_TALK",
+			"name": "ReleaseDraft_talk"
 		}
 	],
 	"ContentHandlers": {
-		"release-yaml": "MediaWiki\\Extension\\PickiPediaReleases\\ReleaseContentHandler"
+		"release-yaml": "MediaWiki\\Extension\\PickiPediaReleases\\ReleaseContentHandler",
+		"release-draft-yaml": "MediaWiki\\Extension\\PickiPediaReleases\\ReleaseDraftContentHandler"
 	},
 	"SpecialPages": {
 		"Releases": "MediaWiki\\Extension\\PickiPediaReleases\\SpecialReleases",
@@ -44,7 +56,8 @@
 		}
 	},
 	"Hooks": {
-		"LoadExtensionSchemaUpdates": "main"
+		"LoadExtensionSchemaUpdates": "main",
+		"BeforePageDisplay": "main"
 	},
 	"MessagesDirs": {
 		"PickiPediaReleases": ["i18n"]
@@ -65,7 +78,12 @@
 		},
 		"ext.pickipediaReleases.uploadAlbum": {
 			"scripts": ["ext.pickipediaReleases.uploadAlbum.js"],
-			"dependencies": ["mediawiki.util"]
+			"dependencies": ["mediawiki.util", "mediawiki.api"]
+		},
+		"ext.pickipediaReleases.releaseDraft": {
+			"scripts": ["ext.pickipediaReleases.releaseDraft.js"],
+			"styles": ["ext.pickipediaReleases.releaseDraft.css"],
+			"dependencies": ["mediawiki.util", "mediawiki.api"]
 		}
 	},
 	"ResourceFileModulePaths": {
@@ -77,6 +95,9 @@
 	],
 	"GroupPermissions": {
 		"sysop": {
+			"upload-to-delivery-kid": true
+		},
+		"release": {
 			"upload-to-delivery-kid": true
 		}
 	},

--- a/extensions/PickiPediaReleases/i18n/en.json
+++ b/extensions/PickiPediaReleases/i18n/en.json
@@ -21,5 +21,8 @@
 	"uploadalbum": "Upload Album",
 	"special-uploadalbum-header": "",
 	"action-upload-to-delivery-kid": "upload content to the delivery-kid pinning service",
-	"right-upload-to-delivery-kid": "Upload content directly to the delivery-kid IPFS pinning service"
+	"right-upload-to-delivery-kid": "Upload content directly to the delivery-kid IPFS pinning service",
+	"releasedraft-missing-draft-id": "Release draft is missing a draft_id field.",
+	"releasedraft-missing-type": "Release draft is missing a type field.",
+	"release-draft-yaml-desc": "YAML metadata for release drafts"
 }

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -1,0 +1,172 @@
+/**
+ * Styles for ReleaseDraft namespace pages.
+ */
+
+/* Status banners */
+.rd-status-banner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.75em 1em;
+	margin-bottom: 1.5em;
+	border-radius: 4px;
+	font-size: 0.95em;
+}
+
+.rd-status-draft {
+	background: #eaf3ff;
+	border: 1px solid #36c;
+	color: #36c;
+}
+
+.rd-status-finalizing {
+	background: #fef6e7;
+	border: 1px solid #ac6600;
+	color: #ac6600;
+}
+
+.rd-status-complete {
+	background: #d5fdf4;
+	border: 1px solid #14866d;
+	color: #14866d;
+}
+
+.rd-status-label {
+	font-weight: bold;
+}
+
+.rd-status-type {
+	font-size: 0.85em;
+	opacity: 0.8;
+}
+
+/* Track list */
+.rd-track-list {
+	margin: 0.5em 0 1.5em;
+}
+
+.rd-track-row {
+	display: flex;
+	align-items: flex-start;
+	padding: 0.6em 0.75em;
+	margin: 0.3em 0;
+	background: #fff;
+	border: 1px solid #c8ccd1;
+	border-radius: 3px;
+	gap: 0.5em;
+}
+
+.rd-track-row[draggable="true"] {
+	cursor: grab;
+}
+
+.rd-track-row.rd-track-dragging {
+	opacity: 0.4;
+}
+
+.rd-track-num {
+	font-weight: bold;
+	min-width: 1.5em;
+	text-align: center;
+	color: #54595d;
+	padding-top: 0.3em;
+}
+
+.rd-track-info {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.4em;
+}
+
+.rd-track-title {
+	width: 100%;
+}
+
+.rd-track-meta {
+	font-size: 0.8em;
+	color: #72777d;
+}
+
+.rd-track-metadata {
+	width: 100%;
+	font-family: monospace;
+	font-size: 0.85em;
+	resize: vertical;
+	min-height: 2.5em;
+}
+
+/* Blockheight section */
+.rd-blockheight-section {
+	margin: 1.5em 0;
+	padding-top: 1em;
+	border-top: 1px solid #eaecf0;
+}
+
+.rd-blockheight-row {
+	display: flex;
+	align-items: center;
+	gap: 0.75em;
+	flex-wrap: wrap;
+}
+
+.rd-blockheight-input {
+	max-width: 200px;
+}
+
+.rd-blockheight-date {
+	font-size: 0.9em;
+	color: #54595d;
+	font-style: italic;
+}
+
+.rd-date-converter {
+	margin-top: 0.5em;
+}
+
+.rd-date-converter label {
+	font-weight: normal;
+	font-size: 0.9em;
+	color: #72777d;
+	margin-right: 0.5em;
+}
+
+.rd-date-input {
+	max-width: 200px;
+}
+
+/* Action buttons */
+.rd-actions {
+	margin: 1.5em 0;
+	padding-top: 1em;
+	border-top: 1px solid #eaecf0;
+	display: flex;
+	align-items: center;
+	gap: 0.75em;
+	flex-wrap: wrap;
+}
+
+/* Album form */
+.rd-album-form {
+	margin-bottom: 1em;
+}
+
+/* Raw YAML toggle */
+.release-raw-yaml {
+	margin-top: 2em;
+	font-size: 0.9em;
+}
+
+.release-raw-yaml summary {
+	cursor: pointer;
+	color: #72777d;
+}
+
+.release-raw-yaml pre {
+	background: #f8f9fa;
+	border: 1px solid #eaecf0;
+	padding: 0.75em;
+	overflow-x: auto;
+	font-size: 0.85em;
+}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -1,0 +1,579 @@
+/**
+ * ReleaseDraft interactive form — JS for the ReleaseDraft namespace.
+ *
+ * Reads draft data from mw.config.get('wgReleaseDraftData'),
+ * provides:
+ * - Track drag-and-drop reorder
+ * - Save button: collect form data → YAML → MediaWiki edit API
+ * - Finalize button: send to delivery-kid /draft-album/{id}/finalize (SSE)
+ * - Blockheight date converter (Etherscan API)
+ */
+( function () {
+	'use strict';
+
+	var draftData = mw.config.get( 'wgReleaseDraftData' ) || {};
+
+	// Blockheight estimation using a known reference point (more accurate than genesis)
+	// The Merge (block 15537394) happened at 2022-09-15T06:42:42Z
+	// Post-merge block time is exactly 12 seconds
+	var MERGE_BLOCK = 15537394;
+	var MERGE_TS = 1663220562; // 2022-09-15T06:42:42Z
+	var POST_MERGE_BLOCK_TIME = 12; // exactly 12 seconds post-merge
+	// Pre-merge: genesis to merge, ~13.3s average
+	var ETH_GENESIS_TS = 1438269973;
+	var PRE_MERGE_AVG = 13.3;
+
+	// -- Helpers --
+
+	function el( id ) {
+		return document.getElementById( id );
+	}
+
+	function setStatus( msg, type ) {
+		var statusEl = el( 'rd-progress-status' );
+		if ( !statusEl ) {
+			return;
+		}
+		statusEl.textContent = msg;
+		statusEl.className = 'uc-status' + ( type ? ' uc-status-' + type : '' );
+	}
+
+	// -- Track drag reorder --
+
+	function initTrackDragReorder() {
+		var container = el( 'rd-track-list' );
+		if ( !container ) {
+			return;
+		}
+
+		var dragSrc = null;
+
+		container.addEventListener( 'dragstart', function ( e ) {
+			var row = e.target.closest( '.rd-track-row' );
+			if ( !row || row.getAttribute( 'draggable' ) === 'false' ) {
+				return;
+			}
+			dragSrc = row;
+			row.classList.add( 'rd-track-dragging' );
+			e.dataTransfer.effectAllowed = 'move';
+		} );
+
+		container.addEventListener( 'dragover', function ( e ) {
+			e.preventDefault();
+			e.dataTransfer.dropEffect = 'move';
+			var row = e.target.closest( '.rd-track-row' );
+			if ( row && row !== dragSrc ) {
+				var rect = row.getBoundingClientRect();
+				var midY = rect.top + rect.height / 2;
+				if ( e.clientY < midY ) {
+					container.insertBefore( dragSrc, row );
+				} else {
+					container.insertBefore( dragSrc, row.nextSibling );
+				}
+			}
+		} );
+
+		container.addEventListener( 'dragend', function () {
+			if ( dragSrc ) {
+				dragSrc.classList.remove( 'rd-track-dragging' );
+				dragSrc = null;
+			}
+			renumberTracks();
+		} );
+	}
+
+	function renumberTracks() {
+		var container = el( 'rd-track-list' );
+		if ( !container ) {
+			return;
+		}
+		var rows = container.querySelectorAll( '.rd-track-row' );
+		rows.forEach( function ( row, idx ) {
+			row.dataset.idx = idx;
+			var num = row.querySelector( '.rd-track-num' );
+			if ( num ) {
+				num.textContent = idx + 1;
+			}
+		} );
+	}
+
+	// -- Collect form data --
+
+	function collectFormData() {
+		var data = JSON.parse( JSON.stringify( draftData ) );
+
+		// Album fields
+		var titleEl = el( 'rd-album-title' );
+		var artistEl = el( 'rd-artist' );
+		var yearEl = el( 'rd-year' );
+		var descEl = el( 'rd-description' );
+
+		if ( !data.album ) {
+			data.album = {};
+		}
+		if ( titleEl ) {
+			data.album.title = titleEl.value;
+		}
+		if ( artistEl ) {
+			data.album.artist = artistEl.value;
+		}
+		if ( yearEl ) {
+			data.album.year = yearEl.value;
+		}
+		if ( descEl ) {
+			data.album.description = descEl.value;
+		}
+
+		// Tracks — collect in current DOM order (respects drag reorder)
+		var trackRows = document.querySelectorAll( '.rd-track-row' );
+		var tracks = [];
+		trackRows.forEach( function ( row ) {
+			var titleInput = row.querySelector( '.rd-track-title' );
+			var metaTextarea = row.querySelector( '.rd-track-metadata' );
+			var filename = row.dataset.filename || '';
+
+			// Find original track data by filename
+			var original = ( draftData.tracks || [] ).find( function ( t ) {
+				return t.filename === filename;
+			} ) || {};
+
+			tracks.push( {
+				filename: filename,
+				title: titleInput ? titleInput.value : ( original.title || '' ),
+				metadata: metaTextarea ? metaTextarea.value : ( original.metadata || '' ),
+				format: original.format || '',
+				duration: original.duration || null,
+				size_bytes: original.size_bytes || null
+			} );
+		} );
+		data.tracks = tracks;
+
+		// Blockheight
+		var bhEl = el( 'rd-blockheight' );
+		if ( bhEl && bhEl.value.trim() ) {
+			data.blockheight = parseInt( bhEl.value.trim(), 10 ) || null;
+		}
+
+		return data;
+	}
+
+	// -- Save draft via MediaWiki API --
+
+	function initSaveButton() {
+		var saveBtn = el( 'rd-save-btn' );
+		if ( !saveBtn ) {
+			return;
+		}
+
+		saveBtn.addEventListener( 'click', function () {
+			saveBtn.disabled = true;
+			setStatus( 'Saving draft...', '' );
+
+			var data = collectFormData();
+
+			// Serialize to YAML-ish format (simple key-value, MediaWiki will store as-is)
+			var yaml = serializeToYaml( data );
+
+			var api = new mw.Api();
+			api.postWithEditToken( {
+				action: 'edit',
+				title: mw.config.get( 'wgPageName' ),
+				text: yaml,
+				summary: 'Update release draft metadata',
+				minor: true
+			} ).then( function () {
+				setStatus( 'Draft saved.', 'success' );
+				saveBtn.disabled = false;
+			} ).fail( function ( code, result ) {
+				setStatus( 'Save failed: ' + ( result.error ? result.error.info : code ), 'error' );
+				saveBtn.disabled = false;
+			} );
+		} );
+	}
+
+	function serializeToYaml( data ) {
+		// Build YAML manually for clean output (no library dependency)
+		var lines = [];
+
+		lines.push( 'draft_id: ' + quote( data.draft_id || '' ) );
+		lines.push( 'type: ' + quote( data.type || 'album' ) );
+		lines.push( 'status: ' + quote( data.status || 'draft' ) );
+
+		if ( data.blockheight ) {
+			lines.push( 'blockheight: ' + data.blockheight );
+		} else {
+			lines.push( 'blockheight: null' );
+		}
+
+		// Album section
+		lines.push( 'album:' );
+		var album = data.album || {};
+		lines.push( '    title: ' + quote( album.title || '' ) );
+		lines.push( '    artist: ' + quote( album.artist || '' ) );
+		lines.push( '    year: ' + quote( album.year || '' ) );
+		lines.push( '    description: ' + quote( album.description || '' ) );
+
+		// Tracks
+		lines.push( 'tracks:' );
+		( data.tracks || [] ).forEach( function ( track ) {
+			lines.push( '    -' );
+			lines.push( '        filename: ' + quote( track.filename || '' ) );
+			lines.push( '        title: ' + quote( track.title || '' ) );
+			if ( track.format ) {
+				lines.push( '        format: ' + quote( track.format ) );
+			}
+			if ( track.duration ) {
+				lines.push( '        duration: ' + track.duration );
+			}
+			if ( track.size_bytes ) {
+				lines.push( '        size_bytes: ' + track.size_bytes );
+			}
+			if ( track.metadata ) {
+				// Multi-line metadata uses YAML literal block scalar
+				lines.push( '        metadata: |' );
+				track.metadata.split( '\n' ).forEach( function ( ml ) {
+					lines.push( '            ' + ml );
+				} );
+			} else {
+				lines.push( '        metadata: ""' );
+			}
+		} );
+
+		// Result section
+		lines.push( 'result:' );
+		var result = data.result || {};
+		lines.push( '    cid: ' + ( result.cid ? quote( result.cid ) : 'null' ) );
+		lines.push( '    gateway_url: ' + ( result.gateway_url ? quote( result.gateway_url ) : 'null' ) );
+
+		return lines.join( '\n' ) + '\n';
+	}
+
+	function quote( val ) {
+		if ( val === '' || val === null || val === undefined ) {
+			return '""';
+		}
+		val = String( val );
+		// Quote if contains special YAML chars
+		if ( /[:#\[\]{}&*!|>'"%@`\n]/.test( val ) || val.trim() !== val ) {
+			return '"' + val.replace( /\\/g, '\\\\' ).replace( /"/g, '\\"' ).replace( /\n/g, '\\n' ) + '"';
+		}
+		return val;
+	}
+
+	// -- Finalize via delivery-kid --
+
+	function initFinalizeButton() {
+		var finalizeBtn = el( 'rd-finalize-btn' );
+		if ( !finalizeBtn ) {
+			return;
+		}
+
+		finalizeBtn.addEventListener( 'click', function () {
+			var data = collectFormData();
+			var draftId = data.draft_id;
+			if ( !draftId ) {
+				setStatus( 'No draft ID — cannot finalize.', 'error' );
+				return;
+			}
+
+			var album = data.album || {};
+			if ( !album.title ) {
+				setStatus( 'Album title is required to finalize.', 'error' );
+				el( 'rd-album-title' ).focus();
+				return;
+			}
+			if ( !album.artist ) {
+				setStatus( 'Artist is required to finalize.', 'error' );
+				el( 'rd-artist' ).focus();
+				return;
+			}
+
+			if ( !confirm( 'Finalize this album? This will transcode, tag, and pin to IPFS.' ) ) {
+				return;
+			}
+
+			finalizeBtn.disabled = true;
+			el( 'rd-save-btn' ).disabled = true;
+
+			var progressDiv = el( 'rd-finalize-progress' );
+			if ( progressDiv ) {
+				progressDiv.style.display = '';
+			}
+			setProgress( 0 );
+			setStatus( 'Starting finalization...', '' );
+
+			// Build track order with per-track metadata
+			var tracks = ( data.tracks || [] ).map( function ( t ) {
+				return {
+					filename: t.filename,
+					title: t.title,
+					metadata: t.metadata || ''
+				};
+			} );
+
+			var apiUrl = mw.config.get( 'wgDeliveryKidUrl' );
+			var authHeaders = {
+				'X-Upload-Token': mw.config.get( 'wgUploadToken' ),
+				'X-Upload-User': mw.config.get( 'wgUploadUser' ),
+				'X-Upload-Timestamp': String( mw.config.get( 'wgUploadTimestamp' ) )
+			};
+
+			var headers = Object.assign( {}, authHeaders, {
+				'Content-Type': 'application/json'
+			} );
+
+			var body = JSON.stringify( {
+				album_title: album.title,
+				artist: album.artist,
+				year: album.year || null,
+				description: album.description || null,
+				tracks: tracks
+			} );
+
+			fetch( apiUrl + '/draft-album/' + draftId + '/finalize', {
+				method: 'POST',
+				headers: headers,
+				body: body
+			} ).then( function ( resp ) {
+				if ( !resp.ok ) {
+					return resp.json().then( function ( err ) {
+						var detail = err.detail;
+						var msg;
+						if ( typeof detail === 'string' ) {
+							msg = detail;
+						} else if ( detail && detail.error ) {
+							msg = detail.error;
+						} else {
+							msg = JSON.stringify( err );
+						}
+						throw new Error( msg );
+					} );
+				}
+				return readSSEStream( resp );
+			} ).catch( function ( err ) {
+				setStatus( 'Finalization error: ' + err.message, 'error' );
+				finalizeBtn.disabled = false;
+				el( 'rd-save-btn' ).disabled = false;
+			} );
+		} );
+	}
+
+	function readSSEStream( resp ) {
+		var reader = resp.body.getReader();
+		var decoder = new TextDecoder();
+		var buffer = '';
+
+		function pump() {
+			return reader.read().then( function ( result ) {
+				if ( result.done ) {
+					return;
+				}
+
+				buffer += decoder.decode( result.value, { stream: true } );
+				var lines = buffer.split( '\n' );
+				buffer = lines.pop();
+
+				var currentEvent = '';
+				for ( var i = 0; i < lines.length; i++ ) {
+					var line = lines[ i ].trim();
+					if ( line.indexOf( 'event:' ) === 0 ) {
+						currentEvent = line.slice( 6 ).trim();
+					} else if ( line.indexOf( 'data:' ) === 0 ) {
+						var sseData = line.slice( 5 ).trim();
+						try {
+							handleSSEEvent( currentEvent, JSON.parse( sseData ) );
+						} catch ( e ) {
+							// skip malformed
+						}
+					}
+				}
+
+				return pump();
+			} );
+		}
+
+		return pump();
+	}
+
+	function handleSSEEvent( event, data ) {
+		if ( event === 'progress' ) {
+			setProgress( data.progress || 0 );
+			var msg = data.message || '';
+			if ( data.track ) {
+				msg += ' (' + data.track + ')';
+			}
+			setStatus( msg, '' );
+		} else if ( event === 'warning' ) {
+			setStatus( 'Warning: ' + data.message, 'warning' );
+		} else if ( event === 'complete' ) {
+			setProgress( 100 );
+			setStatus( 'Album pinned to IPFS!', 'success' );
+			saveResultToPage( data );
+		} else if ( event === 'error' ) {
+			setStatus( 'Error: ' + ( data.message || 'Unknown error' ), 'error' );
+			var finalizeBtn = el( 'rd-finalize-btn' );
+			var saveBtn = el( 'rd-save-btn' );
+			if ( finalizeBtn ) {
+				finalizeBtn.disabled = false;
+			}
+			if ( saveBtn ) {
+				saveBtn.disabled = false;
+			}
+		}
+	}
+
+	function setProgress( pct ) {
+		var fill = document.querySelector( '#rd-progress-bar .uc-progress-fill' );
+		if ( fill ) {
+			fill.style.width = pct + '%';
+		}
+	}
+
+	function saveResultToPage( resultData ) {
+		// Update local data with result, change status to complete
+		var data = collectFormData();
+		data.status = 'complete';
+		data.result = {
+			cid: resultData.cid || null,
+			gateway_url: resultData.gateway_url || null
+		};
+
+		var yaml = serializeToYaml( data );
+		var api = new mw.Api();
+		api.postWithEditToken( {
+			action: 'edit',
+			title: mw.config.get( 'wgPageName' ),
+			text: yaml,
+			summary: 'Finalized: pinned to IPFS as ' + ( resultData.cid || 'unknown' )
+		} ).then( function () {
+			setStatus( 'Saved! Reloading...', 'success' );
+			window.location.reload();
+		} ).fail( function ( code, result ) {
+			setStatus( 'Pinned to IPFS but failed to save page: ' +
+				( result.error ? result.error.info : code ) + '. CID: ' + resultData.cid, 'error' );
+		} );
+	}
+
+	// -- Blockheight converter --
+
+	function initBlockheightConverter() {
+		var nowBtn = el( 'rd-blockheight-now' );
+		var bhInput = el( 'rd-blockheight' );
+		var dateLabel = el( 'rd-blockheight-date' );
+		var dateInput = el( 'rd-date-input' );
+
+		if ( !nowBtn || !bhInput ) {
+			return;
+		}
+
+		// "Current Block" button — fetch latest via public Ethereum RPC
+		nowBtn.addEventListener( 'click', function () {
+			nowBtn.disabled = true;
+			nowBtn.textContent = 'Fetching...';
+
+			fetch( 'https://ethereum-rpc.publicnode.com', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify( {
+					jsonrpc: '2.0',
+					method: 'eth_blockNumber',
+					params: [],
+					id: 1
+				} )
+			} )
+				.then( function ( r ) { return r.json(); } )
+				.then( function ( resp ) {
+					if ( resp.result ) {
+						var blockNum = parseInt( resp.result, 16 );
+						bhInput.value = blockNum;
+						updateBlockDate( blockNum );
+					}
+				} )
+				.catch( function () {
+					// Fallback: estimate from current time
+					var now = Math.floor( Date.now() / 1000 );
+					var estimated = timestampToBlock( now );
+					bhInput.value = estimated;
+					updateBlockDate( estimated );
+				} )
+				.finally( function () {
+					nowBtn.disabled = false;
+					nowBtn.textContent = 'Current Block';
+				} );
+		} );
+
+		// When user types a block number, estimate the date
+		bhInput.addEventListener( 'change', function () {
+			var val = parseInt( bhInput.value, 10 );
+			if ( val > 0 ) {
+				updateBlockDate( val );
+			} else if ( dateLabel ) {
+				dateLabel.textContent = '';
+			}
+		} );
+
+		// Date picker → estimate block number
+		if ( dateInput ) {
+			dateInput.addEventListener( 'change', function () {
+				var dateStr = dateInput.value;
+				if ( !dateStr ) {
+					return;
+				}
+				var ts = Math.floor( new Date( dateStr + 'T12:00:00Z' ).getTime() / 1000 );
+				var estimated = timestampToBlock( ts );
+				if ( estimated > 0 ) {
+					bhInput.value = estimated;
+					updateBlockDate( estimated );
+				}
+			} );
+		}
+
+		// Show date for existing value on load
+		var existingVal = parseInt( bhInput.value, 10 );
+		if ( existingVal > 0 ) {
+			updateBlockDate( existingVal );
+		}
+	}
+
+	function blockToTimestamp( blockNumber ) {
+		if ( blockNumber >= MERGE_BLOCK ) {
+			// Post-merge: exactly 12s per block from the merge point
+			return MERGE_TS + ( ( blockNumber - MERGE_BLOCK ) * POST_MERGE_BLOCK_TIME );
+		}
+		// Pre-merge: estimate from genesis with ~13.3s average
+		return ETH_GENESIS_TS + ( blockNumber * PRE_MERGE_AVG );
+	}
+
+	function timestampToBlock( ts ) {
+		if ( ts >= MERGE_TS ) {
+			return MERGE_BLOCK + Math.floor( ( ts - MERGE_TS ) / POST_MERGE_BLOCK_TIME );
+		}
+		return Math.floor( ( ts - ETH_GENESIS_TS ) / PRE_MERGE_AVG );
+	}
+
+	function updateBlockDate( blockNumber ) {
+		var dateLabel = el( 'rd-blockheight-date' );
+		if ( !dateLabel ) {
+			return;
+		}
+		var estimatedTs = blockToTimestamp( blockNumber );
+		var date = new Date( estimatedTs * 1000 );
+		dateLabel.textContent = '≈ ' + date.toLocaleDateString( 'en-US', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric'
+		} );
+	}
+
+	// -- Init --
+
+	function init() {
+		initTrackDragReorder();
+		initSaveButton();
+		initFinalizeButton();
+		initBlockheightConverter();
+	}
+
+	mw.loader.using( [ 'mediawiki.util', 'mediawiki.api' ] ).then( init );
+
+}() );

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
@@ -1,10 +1,8 @@
 /**
  * Upload Album — direct upload to delivery-kid from browser.
  *
- * Three-step flow using /draft-album:
- * 1. Upload audio + cover → delivery-kid analyzes tracks
- * 2. Review: reorder tracks, edit titles, set album metadata
- * 3. Finalize → transcode FLAC/WAV→OGG, embed tags, pin to IPFS
+ * After upload+analysis, creates a ReleaseDraft wiki page and redirects there.
+ * The ReleaseDraft namespace handles review, metadata editing, and finalization.
  */
 ( function () {
 	'use strict';
@@ -15,26 +13,6 @@
 		'X-Upload-User': mw.config.get( 'wgUploadUser' ),
 		'X-Upload-Timestamp': String( mw.config.get( 'wgUploadTimestamp' ) )
 	};
-
-	var currentDraftId = null;
-	var draftFiles = []; // analyzed files from draft response
-
-	// -- URL draft persistence --
-
-	function getDraftIdFromUrl() {
-		var params = new URLSearchParams( window.location.search );
-		return params.get( 'draft' );
-	}
-
-	function setDraftIdInUrl( draftId ) {
-		var url = new URL( window.location.href );
-		if ( draftId ) {
-			url.searchParams.set( 'draft', draftId );
-		} else {
-			url.searchParams.delete( 'draft' );
-		}
-		history.replaceState( null, '', url.toString() );
-	}
 
 	// -- Helpers --
 
@@ -48,13 +26,6 @@
 		e.className = 'uc-status' + ( type ? ' uc-status-' + type : '' );
 	}
 
-	function showStep( stepId ) {
-		document.querySelectorAll( '.uc-step' ).forEach( function ( s ) {
-			s.classList.remove( 'uc-step-active' );
-		} );
-		el( stepId ).classList.add( 'uc-step-active' );
-	}
-
 	function formatSize( bytes ) {
 		var units = [ 'B', 'KB', 'MB', 'GB' ];
 		var size = bytes;
@@ -66,16 +37,7 @@
 		return size.toFixed( 1 ) + ' ' + units[ i ];
 	}
 
-	function formatDuration( seconds ) {
-		if ( !seconds ) {
-			return '';
-		}
-		var m = Math.floor( seconds / 60 );
-		var s = Math.floor( seconds % 60 );
-		return m + ':' + ( s < 10 ? '0' : '' ) + s;
-	}
-
-	// -- Step 1: File Upload --
+	// -- File Upload --
 
 	function initUploadStep() {
 		var dropzone = el( 'ua-dropzone' );
@@ -162,7 +124,6 @@
 		var xhr = new XMLHttpRequest();
 		xhr.open( 'POST', API_URL + '/draft-album' );
 
-		// Set auth headers
 		Object.keys( AUTH_HEADERS ).forEach( function ( key ) {
 			xhr.setRequestHeader( key, AUTH_HEADERS[ key ] );
 		} );
@@ -204,15 +165,10 @@
 			}
 
 			var draft = JSON.parse( xhr.responseText );
-			currentDraftId = draft.draft_id;
-			draftFiles = draft.files;
-			setDraftIdInUrl( currentDraftId );
-
 			setStatus( 'ua-upload-status',
-				'Draft created. ' + draftFiles.length + ' track(s) analyzed.', 'success' );
+				'Draft created. ' + draft.files.length + ' track(s) analyzed. Creating draft page...', 'success' );
 
-			renderReview( draft );
-			showStep( 'ua-step-review' );
+			createReleaseDraftPage( draft );
 		} );
 
 		xhr.addEventListener( 'error', function () {
@@ -224,351 +180,94 @@
 		xhr.send( formData );
 	}
 
-	// -- Step 2: Review & Track Ordering --
+	// -- Create ReleaseDraft wiki page and redirect --
 
-	function renderReview( draft ) {
-		// Show analysis summary
-		var info = el( 'ua-draft-info' );
-		var totalDuration = 0;
-		var totalSize = 0;
-		var formats = {};
+	function createReleaseDraftPage( draft ) {
+		var draftId = draft.draft_id;
+		var pageName = 'ReleaseDraft:' + draftId;
 
-		draft.files.forEach( function ( f ) {
-			if ( f.duration_seconds ) {
-				totalDuration += f.duration_seconds;
-			}
-			if ( f.size_bytes ) {
-				totalSize += f.size_bytes;
-			}
-			formats[ f.format ] = ( formats[ f.format ] || 0 ) + 1;
+		// Build initial YAML from delivery-kid analysis
+		var tracks = ( draft.files || [] ).map( function ( f ) {
+			var title = f.detected_title || f.original_filename.replace( /\.[^.]+$/, '' );
+			return {
+				filename: f.original_filename,
+				title: title,
+				format: f.format || '',
+				duration: f.duration_seconds || null,
+				size_bytes: f.size_bytes || null,
+				metadata: ''
+			};
 		} );
 
-		var formatSummary = Object.keys( formats ).map( function ( fmt ) {
-			return formats[ fmt ] + ' ' + fmt;
-		} ).join( ', ' );
+		var yaml = buildYaml( draftId, tracks );
 
-		info.innerHTML =
-			'<p>' + draft.files.length + ' tracks &middot; ' +
-			formatDuration( totalDuration ) + ' total &middot; ' +
-			formatSize( totalSize ) + ' &middot; ' + formatSummary + '</p>' +
-			'<p class="uc-draft-expires">Draft expires: ' +
-			new Date( draft.expires_at ).toLocaleString() + '</p>';
-
-		// Render track list
-		renderTrackList( draft.files );
-	}
-
-	function renderTrackList( files ) {
-		var container = el( 'ua-track-list' );
-		container.innerHTML = '';
-
-		files.forEach( function ( file, idx ) {
-			var row = document.createElement( 'div' );
-			row.className = 'ua-track-row';
-			row.draggable = true;
-			row.dataset.idx = idx;
-
-			var title = file.detected_title || file.original_filename.replace( /\.[^.]+$/, '' );
-
-			row.innerHTML =
-				'<span class="ua-track-handle" title="Drag to reorder">&#9776;</span>' +
-				'<span class="ua-track-num">' + ( idx + 1 ) + '</span>' +
-				'<input type="text" class="ua-track-title cdx-text-input__input" ' +
-					'value="' + mw.html.escape( title ) + '" ' +
-					'data-filename="' + mw.html.escape( file.original_filename ) + '">' +
-				'<span class="ua-track-meta">' +
-					mw.html.escape( file.format ) + ' &middot; ' +
-					formatDuration( file.duration_seconds ) + ' &middot; ' +
-					formatSize( file.size_bytes ) +
-				'</span>';
-
-			container.appendChild( row );
-		} );
-
-		initDragReorder( container );
-	}
-
-	function initDragReorder( container ) {
-		var dragSrc = null;
-
-		container.addEventListener( 'dragstart', function ( e ) {
-			var row = e.target.closest( '.ua-track-row' );
-			if ( !row ) {
-				return;
+		var api = new mw.Api();
+		api.postWithEditToken( {
+			action: 'edit',
+			title: pageName,
+			text: yaml,
+			summary: 'New album draft: ' + draft.files.length + ' tracks uploaded',
+			createonly: true
+		} ).then( function () {
+			// Redirect to the new draft page
+			window.location.href = mw.util.getUrl( pageName );
+		} ).fail( function ( code, result ) {
+			if ( code === 'articleexists' ) {
+				// Draft page already exists (maybe re-upload?) — just redirect
+				window.location.href = mw.util.getUrl( pageName );
+			} else {
+				setStatus( 'ua-upload-status',
+					'Failed to create draft page: ' + ( result.error ? result.error.info : code ), 'error' );
+				el( 'ua-upload-btn' ).disabled = false;
 			}
-			dragSrc = row;
-			row.classList.add( 'ua-track-dragging' );
-			e.dataTransfer.effectAllowed = 'move';
-		} );
-
-		container.addEventListener( 'dragover', function ( e ) {
-			e.preventDefault();
-			e.dataTransfer.dropEffect = 'move';
-			var row = e.target.closest( '.ua-track-row' );
-			if ( row && row !== dragSrc ) {
-				var rect = row.getBoundingClientRect();
-				var midY = rect.top + rect.height / 2;
-				if ( e.clientY < midY ) {
-					container.insertBefore( dragSrc, row );
-				} else {
-					container.insertBefore( dragSrc, row.nextSibling );
-				}
-			}
-		} );
-
-		container.addEventListener( 'dragend', function () {
-			if ( dragSrc ) {
-				dragSrc.classList.remove( 'ua-track-dragging' );
-				dragSrc = null;
-			}
-			renumberTracks( container );
 		} );
 	}
 
-	function renumberTracks( container ) {
-		var rows = container.querySelectorAll( '.ua-track-row' );
-		rows.forEach( function ( row, idx ) {
-			row.dataset.idx = idx;
-			row.querySelector( '.ua-track-num' ).textContent = idx + 1;
+	function buildYaml( draftId, tracks ) {
+		var lines = [];
+		lines.push( 'draft_id: ' + draftId );
+		lines.push( 'type: album' );
+		lines.push( 'status: draft' );
+		lines.push( 'blockheight: null' );
+		lines.push( 'album:' );
+		lines.push( '    title: ""' );
+		lines.push( '    artist: ""' );
+		lines.push( '    year: ""' );
+		lines.push( '    description: ""' );
+		lines.push( 'tracks:' );
+
+		tracks.forEach( function ( track ) {
+			lines.push( '    -' );
+			lines.push( '        filename: ' + quote( track.filename ) );
+			lines.push( '        title: ' + quote( track.title ) );
+			if ( track.format ) {
+				lines.push( '        format: ' + quote( track.format ) );
+			}
+			if ( track.duration ) {
+				lines.push( '        duration: ' + track.duration );
+			}
+			if ( track.size_bytes ) {
+				lines.push( '        size_bytes: ' + track.size_bytes );
+			}
+			lines.push( '        metadata: ""' );
 		} );
+
+		lines.push( 'result:' );
+		lines.push( '    cid: null' );
+		lines.push( '    gateway_url: null' );
+
+		return lines.join( '\n' ) + '\n';
 	}
 
-	function getTrackOrder() {
-		var rows = el( 'ua-track-list' ).querySelectorAll( '.ua-track-row' );
-		var tracks = [];
-		rows.forEach( function ( row ) {
-			var input = row.querySelector( '.ua-track-title' );
-			tracks.push( {
-				filename: input.dataset.filename,
-				title: input.value
-			} );
-		} );
-		return tracks;
-	}
-
-	function initReviewStep() {
-		el( 'ua-finalize-btn' ).addEventListener( 'click', function () {
-			var albumTitle = el( 'ua-album-title' ).value.trim();
-			var artist = el( 'ua-artist' ).value.trim();
-
-			if ( !albumTitle ) {
-				setStatus( 'ua-upload-status', 'Album title is required.', 'error' );
-				el( 'ua-album-title' ).focus();
-				return;
-			}
-			if ( !artist ) {
-				setStatus( 'ua-upload-status', 'Artist is required.', 'error' );
-				el( 'ua-artist' ).focus();
-				return;
-			}
-
-			startFinalization();
-		} );
-
-		el( 'ua-delete-draft-btn' ).addEventListener( 'click', function () {
-			if ( !currentDraftId || !confirm( 'Delete this draft? This cannot be undone.' ) ) {
-				return;
-			}
-			fetch( API_URL + '/draft-album/' + currentDraftId, {
-				method: 'DELETE',
-				headers: AUTH_HEADERS
-			} ).then( function () {
-				currentDraftId = null;
-				draftFiles = [];
-				setDraftIdInUrl( null );
-				showStep( 'ua-step-upload' );
-				setStatus( 'ua-upload-status', 'Draft deleted.', '' );
-			} );
-		} );
-	}
-
-	// -- Step 3: Finalize --
-
-	function startFinalization() {
-		if ( !currentDraftId ) {
-			return;
+	function quote( val ) {
+		if ( val === '' || val === null || val === undefined ) {
+			return '""';
 		}
-
-		showStep( 'ua-step-progress' );
-		setProgress( 0 );
-		setStatus( 'ua-progress-status', 'Starting album finalization...', '' );
-
-		var headers = Object.assign( {}, AUTH_HEADERS, {
-			'Content-Type': 'application/json'
-		} );
-
-		var body = JSON.stringify( {
-			album_title: el( 'ua-album-title' ).value.trim(),
-			artist: el( 'ua-artist' ).value.trim(),
-			year: el( 'ua-year' ).value.trim() || null,
-			description: el( 'ua-description' ).value.trim() || null,
-			tracks: getTrackOrder()
-		} );
-
-		fetch( API_URL + '/draft-album/' + currentDraftId + '/finalize', {
-			method: 'POST',
-			headers: headers,
-			body: body
-		} ).then( function ( resp ) {
-			if ( !resp.ok ) {
-				return resp.json().then( function ( err ) {
-					throw new Error( err.detail || resp.statusText );
-				} );
-			}
-			return readSSEStream( resp );
-		} ).catch( function ( err ) {
-			setStatus( 'ua-progress-status', 'Error: ' + err.message, 'error' );
-		} );
-	}
-
-	function readSSEStream( resp ) {
-		var reader = resp.body.getReader();
-		var decoder = new TextDecoder();
-		var buffer = '';
-
-		function pump() {
-			return reader.read().then( function ( result ) {
-				if ( result.done ) {
-					return;
-				}
-
-				buffer += decoder.decode( result.value, { stream: true } );
-				var lines = buffer.split( '\n' );
-				buffer = lines.pop();
-
-				var currentEvent = '';
-				for ( var i = 0; i < lines.length; i++ ) {
-					var line = lines[ i ].trim();
-					if ( line.indexOf( 'event:' ) === 0 ) {
-						currentEvent = line.slice( 6 ).trim();
-					} else if ( line.indexOf( 'data:' ) === 0 ) {
-						var data = line.slice( 5 ).trim();
-						try {
-							handleSSEEvent( currentEvent, JSON.parse( data ) );
-						} catch ( e ) {
-							// skip malformed
-						}
-					}
-				}
-
-				return pump();
-			} );
+		val = String( val );
+		if ( /[:#\[\]{}&*!|>'"%@`\n]/.test( val ) || val.trim() !== val ) {
+			return '"' + val.replace( /\\/g, '\\\\' ).replace( /"/g, '\\"' ).replace( /\n/g, '\\n' ) + '"';
 		}
-
-		return pump();
-	}
-
-	function handleSSEEvent( event, data ) {
-		if ( event === 'progress' ) {
-			setProgress( data.progress || 0 );
-			var msg = data.message || '';
-			if ( data.track ) {
-				msg += ' (' + data.track + ')';
-			}
-			setStatus( 'ua-progress-status', msg, '' );
-		} else if ( event === 'warning' ) {
-			setStatus( 'ua-progress-status', 'Warning: ' + data.message, 'warning' );
-		} else if ( event === 'complete' ) {
-			setProgress( 100 );
-			setStatus( 'ua-progress-status', 'Album pinned!', 'success' );
-			renderResult( data );
-			currentDraftId = null;
-			draftFiles = [];
-			setDraftIdInUrl( null );
-		} else if ( event === 'error' ) {
-			setStatus( 'ua-progress-status',
-				'Error: ' + ( data.message || 'Unknown error' ), 'error' );
-		}
-	}
-
-	function setProgress( pct ) {
-		var fill = document.querySelector( '#ua-progress-bar .uc-progress-fill' );
-		if ( fill ) {
-			fill.style.width = pct + '%';
-		}
-	}
-
-	function renderResult( data ) {
-		var resultEl = el( 'ua-result' );
-		var releaseUrl = mw.util.getUrl( 'Release:' + data.cid );
-
-		var html = '<div class="uc-result-card">';
-		html += '<h4>' + mw.html.escape( data.album_title || 'Album' ) +
-			' &mdash; ' + mw.html.escape( data.artist || '' ) + '</h4>';
-		html += '<table class="wikitable">';
-		html += '<tr><th>CID</th><td class="release-cid-cell">' +
-			mw.html.escape( data.cid ) + '</td></tr>';
-		if ( data.gateway_url ) {
-			html += '<tr><th>Gateway</th><td><a href="' + mw.html.escape( data.gateway_url ) +
-				'" target="_blank">' + mw.html.escape( data.gateway_url ) + '</a></td></tr>';
-		}
-		html += '<tr><th>Pinata</th><td>' + ( data.pinata ? 'Yes' : 'No' ) + '</td></tr>';
-		html += '</table>';
-
-		// Track listing
-		if ( data.tracks && data.tracks.length ) {
-			html += '<h5>Tracks</h5><ol>';
-			data.tracks.forEach( function ( t ) {
-				html += '<li>' + mw.html.escape( t.title || t.filename ) + '</li>';
-			} );
-			html += '</ol>';
-		}
-
-		html += '<p><a href="' + mw.html.escape( releaseUrl ) +
-			'" class="cdx-button cdx-button--action-progressive">Create Release Page</a></p>';
-		html += '<button id="ua-start-over" class="cdx-button">Upload Another Album</button>';
-		html += '</div>';
-
-		resultEl.innerHTML = html;
-
-		el( 'ua-start-over' ).addEventListener( 'click', function () {
-			resultEl.innerHTML = '';
-			showStep( 'ua-step-upload' );
-		} );
-	}
-
-	// -- Resume draft --
-
-	function resumeDraft( draftId ) {
-		setStatus( 'ua-upload-status', 'Resuming draft ' + draftId.slice( 0, 8 ) + '...', '' );
-
-		fetch( API_URL + '/draft-album/' + draftId, {
-			headers: AUTH_HEADERS
-		} ).then( function ( resp ) {
-			if ( resp.status === 410 ) {
-				setStatus( 'ua-upload-status', 'That draft has expired. Upload again.', 'error' );
-				setDraftIdInUrl( null );
-				return;
-			}
-			if ( resp.status === 404 ) {
-				setStatus( 'ua-upload-status', 'Draft not found. It may have been deleted or finalized.', 'error' );
-				setDraftIdInUrl( null );
-				return;
-			}
-			if ( !resp.ok ) {
-				return resp.json().then( function ( err ) {
-					var msg = ( err.detail && typeof err.detail === 'string' ) ? err.detail : JSON.stringify( err );
-					setStatus( 'ua-upload-status', 'Could not resume draft: ' + msg, 'error' );
-					setDraftIdInUrl( null );
-				} );
-			}
-			return resp.json();
-		} ).then( function ( draft ) {
-			if ( !draft ) {
-				return;
-			}
-			currentDraftId = draft.draft_id;
-			draftFiles = draft.files;
-
-			setStatus( 'ua-upload-status',
-				'Draft resumed. ' + draftFiles.length + ' track(s).', 'success' );
-
-			renderReview( draft );
-			showStep( 'ua-step-review' );
-		} ).catch( function ( err ) {
-			setStatus( 'ua-upload-status', 'Network error resuming draft: ' + err.message, 'error' );
-			setDraftIdInUrl( null );
-		} );
+		return val;
 	}
 
 	// -- Init --
@@ -581,15 +280,8 @@
 		}
 
 		initUploadStep();
-		initReviewStep();
-
-		// Check for draft ID in URL (resume after page reload or shared link)
-		var urlDraftId = getDraftIdFromUrl();
-		if ( urlDraftId ) {
-			resumeDraft( urlDraftId );
-		}
 	}
 
-	mw.loader.using( 'mediawiki.util' ).then( init );
+	mw.loader.using( [ 'mediawiki.util', 'mediawiki.api' ] ).then( init );
 
 }() );

--- a/extensions/PickiPediaReleases/src/Hooks.php
+++ b/extensions/PickiPediaReleases/src/Hooks.php
@@ -10,22 +10,54 @@ namespace MediaWiki\Extension\PickiPediaReleases;
 
 use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
 use MediaWiki\Installer\DatabaseUpdater;
+use MediaWiki\Hook\BeforePageDisplayHook;
+use MediaWiki\Output\OutputPage;
+use Skin;
 
-class Hooks implements LoadExtensionSchemaUpdatesHook {
+class Hooks implements LoadExtensionSchemaUpdatesHook, BeforePageDisplayHook {
 
 	/**
 	 * Handle schema updates
-	 *
-	 * Currently no custom tables needed - releases are stored as page content.
-	 * This hook is reserved for future use (e.g., caching release metadata).
 	 *
 	 * @param DatabaseUpdater $updater
 	 */
 	public function onLoadExtensionSchemaUpdates( $updater ): void {
 		// No schema updates needed at this time
-		// Releases are stored as page content in the Release namespace
+	}
 
-		// Future: Could add a cache table for faster API queries
-		// $updater->addExtensionTable( 'release_cache', __DIR__ . '/../sql/release_cache.sql' );
+	/**
+	 * Inject delivery-kid auth config when viewing ReleaseDraft pages.
+	 *
+	 * The content handler loads the JS module, but HMAC tokens must be
+	 * generated per-request with the current user's identity.
+	 *
+	 * @param OutputPage $out
+	 * @param Skin $skin
+	 */
+	public function onBeforePageDisplay( $out, $skin ): void {
+		$title = $out->getTitle();
+		if ( !$title || $title->getNamespace() !== NS_RELEASEDRAFT ) {
+			return;
+		}
+
+		$config = $out->getConfig();
+		$apiKey = $config->get( 'DeliveryKidApiKey' );
+		$apiUrl = $config->get( 'DeliveryKidUrl' );
+
+		if ( !$apiKey || !$apiUrl ) {
+			return;
+		}
+
+		$user = $out->getUser();
+		$username = $user->getName();
+		$timestamp = (int)( microtime( true ) * 1000 );
+		$token = hash_hmac( 'sha256', "upload:{$username}:{$timestamp}", $apiKey );
+
+		$out->addJsConfigVars( [
+			'wgDeliveryKidUrl' => $apiUrl,
+			'wgUploadToken' => $token,
+			'wgUploadUser' => $username,
+			'wgUploadTimestamp' => $timestamp,
+		] );
 	}
 }

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContent.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContent.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Content class for ReleaseDraft pages with YAML metadata.
+ *
+ * Stores structured data about a draft release:
+ * - delivery-kid draft ID (referencing files on storage)
+ * - type (album, content, etc.)
+ * - status (draft, finalizing, complete)
+ * - blockheight for temporal reference
+ * - type-specific metadata (album info, tracks, etc.)
+ * - result data after finalization (CID, gateway URL)
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+namespace MediaWiki\Extension\PickiPediaReleases;
+
+use Content;
+use MediaWiki\Content\AbstractContent;
+use StatusValue;
+use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Yaml\Exception\ParseException;
+
+class ReleaseDraftContent extends AbstractContent {
+
+	/** @var string Raw YAML text */
+	private string $yamlText;
+
+	/** @var array|null Parsed data, cached */
+	private ?array $parsedData = null;
+
+	/** @var ParseException|null Parse error, if any */
+	private ?ParseException $parseError = null;
+
+	public function __construct( string $text ) {
+		parent::__construct( 'release-draft-yaml' );
+		$this->yamlText = $text;
+	}
+
+	public function getText(): string {
+		return $this->yamlText;
+	}
+
+	public function getData(): array {
+		if ( $this->parsedData === null ) {
+			$this->parseYaml();
+		}
+		return $this->parsedData ?? [];
+	}
+
+	public function getParseError(): ?ParseException {
+		if ( $this->parsedData === null && $this->parseError === null ) {
+			$this->parseYaml();
+		}
+		return $this->parseError;
+	}
+
+	private function parseYaml(): void {
+		try {
+			$data = Yaml::parse( $this->yamlText );
+			$this->parsedData = is_array( $data ) ? $data : [];
+			$this->parseError = null;
+		} catch ( ParseException $e ) {
+			$this->parsedData = [];
+			$this->parseError = $e;
+		}
+	}
+
+	// -- Getters --
+
+	public function getDraftId(): ?string {
+		return $this->getData()['draft_id'] ?? null;
+	}
+
+	public function getDraftType(): string {
+		return $this->getData()['type'] ?? 'album';
+	}
+
+	public function getStatus(): string {
+		return $this->getData()['status'] ?? 'draft';
+	}
+
+	public function getBlockheight(): ?int {
+		$bh = $this->getData()['blockheight'] ?? null;
+		return $bh !== null ? (int)$bh : null;
+	}
+
+	public function getAlbumData(): array {
+		return $this->getData()['album'] ?? [];
+	}
+
+	public function getTracks(): array {
+		return $this->getData()['tracks'] ?? [];
+	}
+
+	public function getResult(): array {
+		return $this->getData()['result'] ?? [];
+	}
+
+	public function getAlbumTitle(): ?string {
+		return $this->getAlbumData()['title'] ?? null;
+	}
+
+	public function getArtist(): ?string {
+		return $this->getAlbumData()['artist'] ?? null;
+	}
+
+	// -- AbstractContent methods --
+
+	public function validate(): StatusValue {
+		$status = StatusValue::newGood();
+
+		if ( $this->getParseError() !== null ) {
+			$status->fatal(
+				'pickipediareleases-invalid-yaml',
+				$this->parseError->getMessage()
+			);
+			return $status;
+		}
+
+		$data = $this->getData();
+		if ( empty( $data['draft_id'] ) ) {
+			$status->fatal( 'releasedraft-missing-draft-id' );
+		}
+		if ( empty( $data['type'] ) ) {
+			$status->fatal( 'releasedraft-missing-type' );
+		}
+
+		return $status;
+	}
+
+	public function isValid(): bool {
+		return $this->validate()->isOK();
+	}
+
+	public function getTextForSearchIndex(): string {
+		$parts = [];
+		$album = $this->getAlbumData();
+		if ( !empty( $album['title'] ) ) {
+			$parts[] = $album['title'];
+		}
+		if ( !empty( $album['artist'] ) ) {
+			$parts[] = $album['artist'];
+		}
+		if ( !empty( $album['description'] ) ) {
+			$parts[] = $album['description'];
+		}
+		foreach ( $this->getTracks() as $track ) {
+			if ( !empty( $track['title'] ) ) {
+				$parts[] = $track['title'];
+			}
+		}
+		return implode( "\n", $parts );
+	}
+
+	public function getWikitextForTransclusion(): string {
+		return $this->yamlText;
+	}
+
+	public function getTextForSummary( $maxLength = 250 ) {
+		$album = $this->getAlbumData();
+		$summary = '';
+		if ( !empty( $album['artist'] ) && !empty( $album['title'] ) ) {
+			$summary = $album['artist'] . ' — ' . $album['title'];
+		} elseif ( !empty( $album['title'] ) ) {
+			$summary = $album['title'];
+		}
+		return $summary ? mb_substr( $summary, 0, $maxLength ) : mb_substr( $this->yamlText, 0, $maxLength );
+	}
+
+	public function getNativeData(): string {
+		return $this->yamlText;
+	}
+
+	public function getSize(): int {
+		return strlen( $this->yamlText );
+	}
+
+	public function copy(): Content {
+		return new ReleaseDraftContent( $this->yamlText );
+	}
+
+	public function isCountable( $hasLinks = null ): bool {
+		return true;
+	}
+
+	public function serialize( $format = null ): string {
+		return $this->yamlText;
+	}
+}

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -1,0 +1,466 @@
+<?php
+/**
+ * Content handler for ReleaseDraft pages.
+ *
+ * Renders type-specific interactive forms:
+ * - Album drafts: track list with reorder, per-track metadata, album fields
+ * - All types: blockheight field, status display, finalize action
+ *
+ * The actual files live on delivery-kid's storage. This page holds
+ * the metadata and serves as the collaborative editing surface.
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+namespace MediaWiki\Extension\PickiPediaReleases;
+
+use Content;
+use MediaWiki\Content\ContentHandler;
+use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Content\ValidationParams;
+use MediaWiki\Html\Html;
+use MediaWiki\Parser\ParserOutput;
+use StatusValue;
+use Symfony\Component\Yaml\Yaml;
+
+class ReleaseDraftContentHandler extends ContentHandler {
+
+	public function __construct( $modelId = 'release-draft-yaml' ) {
+		parent::__construct( $modelId, [ CONTENT_FORMAT_TEXT ] );
+	}
+
+	public function serializeContent( Content $content, $format = null ): string {
+		if ( !$content instanceof ReleaseDraftContent ) {
+			throw new \InvalidArgumentException( 'Expected ReleaseDraftContent' );
+		}
+		return $content->getText();
+	}
+
+	public function unserializeContent( $text, $format = null ): ReleaseDraftContent {
+		return new ReleaseDraftContent( $text );
+	}
+
+	public function makeEmptyContent(): ReleaseDraftContent {
+		$yaml = Yaml::dump( [
+			'draft_id' => '',
+			'type' => 'album',
+			'status' => 'draft',
+			'blockheight' => null,
+			'album' => [
+				'title' => '',
+				'artist' => '',
+				'year' => '',
+				'description' => '',
+			],
+			'tracks' => [],
+			'result' => [
+				'cid' => null,
+				'gateway_url' => null,
+			],
+		], 4, 2 );
+		return new ReleaseDraftContent( $yaml );
+	}
+
+	public function validateSave(
+		Content $content,
+		ValidationParams $validationParams
+	): StatusValue {
+		if ( !$content instanceof ReleaseDraftContent ) {
+			return StatusValue::newFatal( 'invalid-content-data' );
+		}
+		return $content->validate();
+	}
+
+	protected function fillParserOutput(
+		Content $content,
+		ContentParseParams $cpoParams,
+		ParserOutput &$output
+	): void {
+		if ( !$content instanceof ReleaseDraftContent ) {
+			$output->setRawText( '<p>Invalid content type</p>' );
+			return;
+		}
+
+		$output->addModuleStyles( [ 'ext.pickipediaReleases.styles', 'ext.pickipediaReleases.upload.styles' ] );
+		$output->addModules( [ 'ext.pickipediaReleases.releaseDraft' ] );
+
+		$html = '';
+		$data = $content->getData();
+		$status = $content->getStatus();
+		$type = $content->getDraftType();
+
+		// Validation errors
+		$validation = $content->validate();
+		if ( !$validation->isOK() ) {
+			$html .= $this->renderValidationErrors( $validation );
+		}
+
+		// Status banner
+		$html .= $this->renderStatusBanner( $status, $data );
+
+		// If complete, show the result
+		if ( $status === 'complete' ) {
+			$html .= $this->renderResult( $data );
+		}
+
+		// Type-specific form
+		if ( $type === 'album' ) {
+			$html .= $this->renderAlbumForm( $data, $status );
+		} else {
+			$html .= $this->renderGenericForm( $data, $status );
+		}
+
+		// Blockheight field (all types)
+		$html .= $this->renderBlockheightField( $data );
+
+		// Action buttons
+		if ( $status === 'draft' ) {
+			$html .= $this->renderActions( $data );
+		}
+
+		// Raw YAML
+		$yamlText = trim( $content->getText() );
+		if ( !empty( $yamlText ) ) {
+			$html .= $this->renderRawYaml( $yamlText );
+		}
+
+		// Pass data to JS
+		$output->setJsConfigVar( 'wgReleaseDraftData', $data );
+
+		$output->setRawText( $html );
+
+		// Categories
+		$output->addCategory( 'Release_Drafts' );
+		if ( $status === 'complete' ) {
+			$output->addCategory( 'Completed_Drafts' );
+		}
+	}
+
+	private function renderStatusBanner( string $status, array $data ): string {
+		$classes = [
+			'draft' => 'rd-status-draft',
+			'finalizing' => 'rd-status-finalizing',
+			'complete' => 'rd-status-complete',
+		];
+		$labels = [
+			'draft' => 'Draft — not yet finalized',
+			'finalizing' => 'Finalizing — processing in progress',
+			'complete' => 'Complete — pinned to IPFS',
+		];
+
+		$class = $classes[$status] ?? 'rd-status-draft';
+		$label = $labels[$status] ?? 'Unknown status';
+
+		$type = $data['type'] ?? 'release';
+
+		return Html::rawElement( 'div', [ 'class' => "rd-status-banner $class" ],
+			Html::element( 'span', [ 'class' => 'rd-status-label' ], $label ) .
+			Html::element( 'span', [ 'class' => 'rd-status-type' ], ucfirst( $type ) . ' draft' )
+		);
+	}
+
+	private function renderResult( array $data ): string {
+		$result = $data['result'] ?? [];
+		if ( empty( $result['cid'] ) ) {
+			return '';
+		}
+
+		$cid = $result['cid'];
+		$gatewayUrl = $result['gateway_url'] ?? "https://ipfs.io/ipfs/{$cid}";
+		$releaseTitle = \MediaWiki\MediaWikiServices::getInstance()
+			->getTitleFactory()->makeTitle( NS_RELEASE, $cid );
+
+		$html = Html::openElement( 'div', [ 'class' => 'uc-result-card' ] );
+		$html .= Html::element( 'h4', [], 'Pinned to IPFS' );
+		$html .= Html::openElement( 'table', [ 'class' => 'wikitable' ] );
+
+		$html .= Html::openElement( 'tr' );
+		$html .= Html::element( 'th', [], 'CID' );
+		$html .= Html::element( 'td', [ 'class' => 'release-cid-cell' ], $cid );
+		$html .= Html::closeElement( 'tr' );
+
+		$html .= Html::openElement( 'tr' );
+		$html .= Html::element( 'th', [], 'Gateway' );
+		$html .= Html::rawElement( 'td', [],
+			Html::element( 'a', [ 'href' => $gatewayUrl, 'target' => '_blank' ], $gatewayUrl )
+		);
+		$html .= Html::closeElement( 'tr' );
+
+		if ( $releaseTitle ) {
+			$html .= Html::openElement( 'tr' );
+			$html .= Html::element( 'th', [], 'Release Page' );
+			$html .= Html::rawElement( 'td', [],
+				Html::element( 'a', [ 'href' => $releaseTitle->getLocalURL() ], $releaseTitle->getPrefixedText() )
+			);
+			$html .= Html::closeElement( 'tr' );
+		}
+
+		$html .= Html::closeElement( 'table' );
+		$html .= Html::closeElement( 'div' );
+
+		return $html;
+	}
+
+	private function renderAlbumForm( array $data, string $status ): string {
+		$album = $data['album'] ?? [];
+		$tracks = $data['tracks'] ?? [];
+		$disabled = $status !== 'draft' ? ' disabled' : '';
+
+		$html = Html::openElement( 'div', [ 'class' => 'rd-album-form', 'id' => 'rd-album-form' ] );
+		$html .= Html::element( 'h3', [], 'Album Info' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'uc-metadata-form' ] );
+
+		// Album title
+		$html .= $this->renderField( 'rd-album-title', 'Album Title',
+			$album['title'] ?? '', 'text', $disabled );
+
+		// Artist
+		$html .= $this->renderField( 'rd-artist', 'Artist',
+			$album['artist'] ?? '', 'text', $disabled );
+
+		// Year
+		$html .= $this->renderField( 'rd-year', 'Year',
+			$album['year'] ?? '', 'text', $disabled );
+
+		// Description
+		$html .= Html::openElement( 'div', [ 'class' => 'uc-field' ] );
+		$html .= Html::element( 'label', [ 'for' => 'rd-description' ], 'Description' );
+		$html .= Html::element( 'textarea', [
+			'id' => 'rd-description',
+			'class' => 'cdx-text-input__input',
+			'rows' => 3,
+			'placeholder' => 'Optional album description',
+			'disabled' => $status !== 'draft' ? true : false,
+		], $album['description'] ?? '' );
+		$html .= Html::closeElement( 'div' );
+
+		$html .= Html::closeElement( 'div' );
+
+		// Track list
+		$html .= Html::element( 'h3', [], 'Tracks' );
+		if ( $status === 'draft' ) {
+			$html .= Html::element( 'p', [ 'class' => 'uc-hint' ], 'Drag to reorder. Metadata field accepts key=value pairs (one per line) for Vorbis comments.' );
+		}
+
+		$html .= Html::openElement( 'div', [ 'id' => 'rd-track-list', 'class' => 'rd-track-list' ] );
+
+		foreach ( $tracks as $idx => $track ) {
+			$html .= $this->renderTrackRow( $idx, $track, $status );
+		}
+
+		$html .= Html::closeElement( 'div' );
+		$html .= Html::closeElement( 'div' );
+
+		return $html;
+	}
+
+	private function renderTrackRow( int $idx, array $track, string $status ): string {
+		$disabled = $status !== 'draft';
+		$num = $idx + 1;
+
+		$html = Html::openElement( 'div', [
+			'class' => 'rd-track-row',
+			'draggable' => $disabled ? 'false' : 'true',
+			'data-idx' => $idx,
+			'data-filename' => $track['filename'] ?? '',
+		] );
+
+		if ( !$disabled ) {
+			$html .= Html::element( 'span', [
+				'class' => 'ua-track-handle',
+				'title' => 'Drag to reorder',
+			], "\u{2630}" );
+		}
+
+		$html .= Html::element( 'span', [ 'class' => 'rd-track-num' ], (string)$num );
+
+		// Track info column
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-track-info' ] );
+
+		// Title input
+		$html .= Html::element( 'input', [
+			'type' => 'text',
+			'class' => 'rd-track-title cdx-text-input__input',
+			'value' => $track['title'] ?? '',
+			'data-filename' => $track['filename'] ?? '',
+			'disabled' => $disabled ? true : false,
+		] );
+
+		// File info
+		$meta = [];
+		if ( !empty( $track['format'] ) ) {
+			$meta[] = htmlspecialchars( $track['format'] );
+		}
+		if ( !empty( $track['duration'] ) ) {
+			$mins = floor( $track['duration'] / 60 );
+			$secs = floor( $track['duration'] % 60 );
+			$meta[] = $mins . ':' . str_pad( (string)$secs, 2, '0', STR_PAD_LEFT );
+		}
+		if ( !empty( $track['size_bytes'] ) ) {
+			$meta[] = $this->formatSize( (int)$track['size_bytes'] );
+		}
+		if ( !empty( $meta ) ) {
+			$html .= Html::rawElement( 'span', [ 'class' => 'rd-track-meta' ],
+				implode( ' &middot; ', $meta )
+			);
+		}
+
+		// Per-track metadata (freetext)
+		$html .= Html::element( 'textarea', [
+			'class' => 'rd-track-metadata',
+			'rows' => 2,
+			'placeholder' => 'COMPOSER=...' . "\n" . 'PERFORMER=...',
+			'disabled' => $disabled ? true : false,
+		], $track['metadata'] ?? '' );
+
+		$html .= Html::closeElement( 'div' );
+		$html .= Html::closeElement( 'div' );
+
+		return $html;
+	}
+
+	private function renderGenericForm( array $data, string $status ): string {
+		// Placeholder for non-album draft types
+		$html = Html::openElement( 'div', [ 'class' => 'rd-generic-form' ] );
+		$html .= Html::element( 'h3', [], 'Content Draft' );
+		$html .= Html::element( 'p', [], 'Draft type: ' . ( $data['type'] ?? 'unknown' ) );
+		$html .= Html::closeElement( 'div' );
+		return $html;
+	}
+
+	private function renderBlockheightField( array $data ): string {
+		$blockheight = $data['blockheight'] ?? '';
+
+		$html = Html::openElement( 'div', [ 'class' => 'rd-blockheight-section' ] );
+		$html .= Html::element( 'h3', [], 'Temporal Reference' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'uc-field' ] );
+		$html .= Html::element( 'label', [ 'for' => 'rd-blockheight' ], 'Ethereum Block Height' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-blockheight-row' ] );
+		$html .= Html::element( 'input', [
+			'type' => 'text',
+			'id' => 'rd-blockheight',
+			'class' => 'cdx-text-input__input rd-blockheight-input',
+			'value' => $blockheight,
+			'placeholder' => 'e.g. 24631327',
+		] );
+		$html .= Html::element( 'button', [
+			'type' => 'button',
+			'id' => 'rd-blockheight-now',
+			'class' => 'cdx-button',
+		], 'Current Block' );
+		$html .= Html::element( 'span', [ 'id' => 'rd-blockheight-date', 'class' => 'rd-blockheight-date' ], '' );
+		$html .= Html::closeElement( 'div' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-date-converter' ] );
+		$html .= Html::element( 'label', [ 'for' => 'rd-date-input' ], 'Or pick a date:' );
+		$html .= Html::element( 'input', [
+			'type' => 'date',
+			'id' => 'rd-date-input',
+			'class' => 'cdx-text-input__input rd-date-input',
+		] );
+		$html .= Html::closeElement( 'div' );
+
+		$html .= Html::closeElement( 'div' );
+		$html .= Html::closeElement( 'div' );
+
+		return $html;
+	}
+
+	private function renderActions( array $data ): string {
+		$draftId = $data['draft_id'] ?? '';
+
+		$html = Html::openElement( 'div', [ 'class' => 'rd-actions', 'id' => 'rd-actions' ] );
+
+		$html .= Html::element( 'button', [
+			'type' => 'button',
+			'id' => 'rd-save-btn',
+			'class' => 'cdx-button cdx-button--action-progressive',
+		], 'Save Draft' );
+
+		$html .= Html::element( 'button', [
+			'type' => 'button',
+			'id' => 'rd-finalize-btn',
+			'class' => 'cdx-button cdx-button--action-progressive cdx-button--weight-primary',
+		], 'Finalize & Pin to IPFS' );
+
+		$html .= Html::openElement( 'div', [
+			'id' => 'rd-finalize-progress',
+			'class' => 'uc-step',
+			'style' => 'display:none',
+		] );
+		$html .= Html::rawElement( 'div', [
+			'id' => 'rd-progress-bar',
+			'class' => 'uc-progress-bar',
+		], Html::element( 'div', [ 'class' => 'uc-progress-fill' ] ) );
+		$html .= Html::element( 'div', [ 'id' => 'rd-progress-status', 'class' => 'uc-status' ] );
+		$html .= Html::closeElement( 'div' );
+
+		$html .= Html::closeElement( 'div' );
+
+		return $html;
+	}
+
+	private function renderField( string $id, string $label, string $value, string $type, string $disabled ): string {
+		$html = Html::openElement( 'div', [ 'class' => 'uc-field' ] );
+		$html .= Html::element( 'label', [ 'for' => $id ], $label );
+		$attrs = [
+			'type' => $type,
+			'id' => $id,
+			'class' => 'cdx-text-input__input',
+			'value' => $value,
+		];
+		if ( $disabled ) {
+			$attrs['disabled'] = true;
+		}
+		$html .= Html::element( 'input', $attrs );
+		$html .= Html::closeElement( 'div' );
+		return $html;
+	}
+
+	private function formatSize( int $bytes ): string {
+		$units = [ 'B', 'KB', 'MB', 'GB' ];
+		$size = (float)$bytes;
+		$i = 0;
+		while ( $size >= 1024 && $i < count( $units ) - 1 ) {
+			$size /= 1024;
+			$i++;
+		}
+		return round( $size, 1 ) . ' ' . $units[$i];
+	}
+
+	private function renderValidationErrors( StatusValue $status ): string {
+		$errors = $status->getMessages( 'error' );
+		$errorHtml = Html::element( 'strong', [], 'Validation Errors:' );
+		$errorList = Html::openElement( 'ul' );
+		foreach ( $errors as $error ) {
+			$errorList .= Html::element( 'li', [], wfMessage( $error )->text() );
+		}
+		$errorList .= Html::closeElement( 'ul' );
+		return Html::rawElement( 'div', [ 'class' => 'release-validation-error' ],
+			$errorHtml . $errorList
+		);
+	}
+
+	private function renderRawYaml( string $yaml ): string {
+		return Html::rawElement( 'details', [ 'class' => 'release-raw-yaml' ],
+			Html::element( 'summary', [], 'Raw YAML' ) .
+			Html::element( 'pre', [], $yaml )
+		);
+	}
+
+	public function supportsDirectEditing(): bool {
+		return true;
+	}
+
+	public function supportsDirectApiEditing(): bool {
+		return true;
+	}
+
+	public function getActionOverrides(): array {
+		return [];
+	}
+}

--- a/extensions/PickiPediaReleases/src/SpecialUploadAlbum.php
+++ b/extensions/PickiPediaReleases/src/SpecialUploadAlbum.php
@@ -59,15 +59,15 @@ class SpecialUploadAlbum extends SpecialPage {
 	}
 
 	/**
-	 * Render the HTML skeleton. JS handles all interactivity.
+	 * Render the HTML skeleton. JS handles upload, then creates a ReleaseDraft page.
 	 */
 	private function renderPageStructure(): string {
 		$html = '';
 
-		// Step 1: File upload
 		$html .= '<div id="ua-step-upload" class="uc-step uc-step-active">';
 		$html .= '<h3>Upload Album Files</h3>';
 		$html .= '<p>Upload audio tracks and optional cover art. Supported formats: FLAC, WAV, OGG, MP3, M4A.</p>';
+		$html .= '<p>After upload, a draft page will be created where you can edit metadata, reorder tracks, and finalize.</p>';
 		$html .= '<div id="ua-dropzone" class="uc-dropzone">';
 		$html .= '<p>Drag audio files here or click to select</p>';
 		$html .= '<p class="uc-hint">FLAC &amp; WAV will be archived and transcoded to OGG</p>';
@@ -77,41 +77,6 @@ class SpecialUploadAlbum extends SpecialPage {
 		$html .= '<button id="ua-upload-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary" disabled>Upload &amp; Analyze</button>';
 		$html .= '<div id="ua-upload-progress" class="uc-progress-bar" style="display:none"><div class="uc-progress-fill"></div></div>';
 		$html .= '<div id="ua-upload-status" class="uc-status"></div>';
-		$html .= '</div>';
-
-		// Step 2: Review tracks and metadata
-		$html .= '<div id="ua-step-review" class="uc-step">';
-		$html .= '<h3>Review &amp; Organize</h3>';
-		$html .= '<div id="ua-draft-info" class="uc-draft-info"></div>';
-
-		// Album metadata
-		$html .= '<div class="uc-metadata-form">';
-		$html .= '<div class="uc-field"><label for="ua-album-title">Album Title</label>';
-		$html .= '<input type="text" id="ua-album-title" class="cdx-text-input__input" placeholder="Album title" required></div>';
-		$html .= '<div class="uc-field"><label for="ua-artist">Artist</label>';
-		$html .= '<input type="text" id="ua-artist" class="cdx-text-input__input" placeholder="Artist name" required></div>';
-		$html .= '<div class="uc-field"><label for="ua-year">Year</label>';
-		$html .= '<input type="text" id="ua-year" class="cdx-text-input__input" placeholder="e.g. 2026"></div>';
-		$html .= '<div class="uc-field"><label for="ua-description">Description</label>';
-		$html .= '<textarea id="ua-description" class="cdx-text-input__input" rows="3" placeholder="Optional album description"></textarea></div>';
-		$html .= '</div>';
-
-		// Track list (populated by JS)
-		$html .= '<h4>Track List <span class="uc-hint">(drag to reorder)</span></h4>';
-		$html .= '<div id="ua-track-list" class="ua-track-list"></div>';
-
-		$html .= '<div class="uc-button-row">';
-		$html .= '<button id="ua-finalize-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">Finalize &amp; Pin</button>';
-		$html .= '<button id="ua-delete-draft-btn" class="cdx-button cdx-button--action-destructive">Delete Draft</button>';
-		$html .= '</div>';
-		$html .= '</div>';
-
-		// Step 3: Progress and result
-		$html .= '<div id="ua-step-progress" class="uc-step">';
-		$html .= '<h3>Processing Album</h3>';
-		$html .= '<div id="ua-progress-bar" class="uc-progress-bar"><div class="uc-progress-fill"></div></div>';
-		$html .= '<div id="ua-progress-status" class="uc-status"></div>';
-		$html .= '<div id="ua-result" class="uc-result"></div>';
 		$html .= '</div>';
 
 		return $html;


### PR DESCRIPTION
## Summary

- New `ReleaseDraft` namespace (3006/3007) with `release-draft-yaml` content model for persistent, collaborative draft editing
- Special:UploadAlbum now creates a ReleaseDraft wiki page after upload and redirects there (instead of inline review/finalize)
- Draft pages render interactive album forms: metadata fields, draggable track list with per-track Vorbis comment textareas, Ethereum blockheight converter
- Save/finalize via JS: save writes YAML back to wiki page, finalize streams SSE from delivery-kid and writes CID result
- BeforePageDisplay hook injects HMAC auth tokens for delivery-kid on draft pages
- Namespace protected by `upload-to-delivery-kid` permission, granted to `sysop` and `release` groups

## Test plan

- [x] Namespace registration (NS_RELEASEDRAFT = 3006) confirmed on demo
- [x] Content handler renders album form with tracks, metadata, blockheight
- [x] Current Block button fetches from public Ethereum RPC
- [x] Date estimation accurate to ~10 days using Merge reference point
- [ ] Full upload → draft page → finalize flow on production