### PR TITLE
Show login message for logged-out users on ReleaseDraft

### DIFF
--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -283,6 +283,15 @@
 			return;
 		}
 
+		// Hide action buttons for logged-out users
+		if ( mw.config.get( 'wgUserId' ) === null ) {
+			var actionsDiv = el( 'rd-actions' );
+			if ( actionsDiv ) {
+				actionsDiv.innerHTML = '<p class="uc-status uc-status-error">You must be logged in to save or finalize drafts.</p>';
+			}
+			return;
+		}
+
 		finalizeBtn.addEventListener( 'click', function () {
 			var data = collectFormData();
 			var draftId = data.draft_id;


### PR DESCRIPTION
## Summary
- Replace Save/Finalize buttons with a clear "You must be logged in" message for anonymous users
- Prevents silent 403 failures

## Test plan
- [x] Logged-out user sees message instead of buttons