### PR TITLE
Add BitTorrent fields to Release pages from finalize

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -243,7 +243,9 @@ wfLoadExtension( 'EmbedVideo' );
 # Stores IPFS CIDs and BitTorrent infohashes for pinning service sync
 wfLoadExtension( 'PickiPediaReleases' );
 $wgDeliveryKidUrl = getenv('DELIVERY_KID_URL') ?: 'https://delivery-kid.cryptograss.live';
-$wgDeliveryKidApiKey = getenv('DELIVERY_KID_API_KEY') ?: '';
+if ( getenv('DELIVERY_KID_API_KEY') ) {
+	$wgDeliveryKidApiKey = getenv('DELIVERY_KID_API_KEY');
+}
 
 # Echo - notifications for talk page messages, mentions, watchlist changes
 wfLoadExtension( 'Echo' );

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -242,6 +242,8 @@ wfLoadExtension( 'EmbedVideo' );
 # PickiPediaReleases - Release namespace with YAML content model
 # Stores IPFS CIDs and BitTorrent infohashes for pinning service sync
 wfLoadExtension( 'PickiPediaReleases' );
+$wgDeliveryKidUrl = getenv('DELIVERY_KID_URL') ?: 'https://delivery-kid.cryptograss.live';
+$wgDeliveryKidApiKey = getenv('DELIVERY_KID_API_KEY') ?: '';
 
 # Echo - notifications for talk page messages, mentions, watchlist changes
 wfLoadExtension( 'Echo' );

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -136,6 +136,9 @@ $wgGroupPermissions['release']['edit'] = true;
 $wgNamespaceProtection[3004] = ['release-edit'];
 $wgGroupPermissions['release']['release-edit'] = true;
 
+# Restrict ReleaseDraft namespace (3006) to users with upload-to-delivery-kid permission
+$wgNamespaceProtection[3006] = ['upload-to-delivery-kid'];
+
 # Make release-edit available as a BotPasswords grant
 $wgGrantPermissions['release-edit']['release-edit'] = true;
 $wgGrantPermissionGroups['release-edit'] = 'other';
@@ -150,8 +153,9 @@ enableSemantics( parse_url($wgServer, PHP_URL_HOST) );
 $smwgNamespacesWithSemanticLinks[NS_CRYPTOGRASS] = true;
 
 # Enable semantic links for Release namespace (after PickiPediaReleases is loaded)
-# Note: NS_RELEASE (3004) is defined by the PickiPediaReleases extension
+# Note: NS_RELEASE (3004) and NS_RELEASEDRAFT (3006) are defined by PickiPediaReleases
 $smwgNamespacesWithSemanticLinks[3004] = true;
+$smwgNamespacesWithSemanticLinks[3006] = true;
 
 # Page Forms - create forms for SMW data entry (installed via Composer)
 wfLoadExtension( 'PageForms' );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - MEDIAWIKI_DB_PASSWORD=${DB_PASSWORD:-changeme}
       - WIKI_URL=${WIKI_URL:-https://pickipedia.justin.hunter.cryptograss.live}
       - WIKI_DEV_MODE=true
+      - DELIVERY_KID_API_KEY=${DELIVERY_KID_API_KEY:-}
     volumes:
       - ${PICKIPEDIA_DIR:-.}/LocalSettings.php:/var/www/html/LocalSettings.php:ro
       - ${PICKIPEDIA_DIR:-.}/LocalSettings.local.php:/var/www/html/LocalSettings.local.php:ro

--- a/extensions/PickiPediaReleases/PickiPediaReleases.alias.php
+++ b/extensions/PickiPediaReleases/PickiPediaReleases.alias.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Aliases for special pages in the PickiPediaReleases extension.
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+$specialPageAliases = [];
+
+/** English (English) */
+$specialPageAliases['en'] = [
+	'Releases' => [ 'Releases' ],
+	'UploadContent' => [ 'UploadContent', 'Upload Content' ],
+];

--- a/extensions/PickiPediaReleases/PickiPediaReleases.alias.php
+++ b/extensions/PickiPediaReleases/PickiPediaReleases.alias.php
@@ -12,4 +12,5 @@ $specialPageAliases = [];
 $specialPageAliases['en'] = [
 	'Releases' => [ 'Releases' ],
 	'UploadContent' => [ 'UploadContent', 'Upload Content' ],
+	'UploadAlbum' => [ 'UploadAlbum', 'Upload Album' ],
 ];

--- a/extensions/PickiPediaReleases/extension.json
+++ b/extensions/PickiPediaReleases/extension.json
@@ -55,11 +55,7 @@
 		"ext.pickipediaReleases.styles": {
 			"styles": ["ext.pickipediaReleases.css"]
 		},
-		"ext.pickipediaReleases.upload": {
-			"scripts": ["ext.pickipediaReleases.upload.js"],
-			"dependencies": ["mediawiki.util"]
-		},
-		"ext.pickipediaReleases.upload.styles": {
+"ext.pickipediaReleases.upload.styles": {
 			"styles": ["ext.pickipediaReleases.upload.css"]
 		}
 	},
@@ -71,6 +67,10 @@
 		"DeliveryKidUrl": {
 			"value": "https://delivery-kid.cryptograss.live",
 			"description": "Base URL for the delivery-kid pinning service API"
+		},
+		"DeliveryKidApiKey": {
+			"value": "",
+			"description": "Shared API key for authenticating with delivery-kid pinning service"
 		}
 	},
 	"manifest_version": 2

--- a/extensions/PickiPediaReleases/extension.json
+++ b/extensions/PickiPediaReleases/extension.json
@@ -29,7 +29,8 @@
 		"release-yaml": "MediaWiki\\Extension\\PickiPediaReleases\\ReleaseContentHandler"
 	},
 	"SpecialPages": {
-		"Releases": "MediaWiki\\Extension\\PickiPediaReleases\\SpecialReleases"
+		"Releases": "MediaWiki\\Extension\\PickiPediaReleases\\SpecialReleases",
+		"UploadContent": "MediaWiki\\Extension\\PickiPediaReleases\\SpecialUploadContent"
 	},
 	"APIModules": {
 		"releaselist": {
@@ -50,12 +51,24 @@
 	"ResourceModules": {
 		"ext.pickipediaReleases.styles": {
 			"styles": ["ext.pickipediaReleases.css"]
+		},
+		"ext.pickipediaReleases.upload": {
+			"scripts": ["ext.pickipediaReleases.upload.js"],
+			"dependencies": ["mediawiki.util"]
+		},
+		"ext.pickipediaReleases.upload.styles": {
+			"styles": ["ext.pickipediaReleases.upload.css"]
 		}
 	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "resources",
 		"remoteExtPath": "PickiPediaReleases/resources"
 	},
-	"config": {},
+	"config": {
+		"DeliveryKidUrl": {
+			"value": "https://delivery-kid.cryptograss.live",
+			"description": "Base URL for the delivery-kid pinning service API"
+		}
+	},
 	"manifest_version": 2
 }

--- a/extensions/PickiPediaReleases/extension.json
+++ b/extensions/PickiPediaReleases/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "PickiPediaReleases",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"author": ["CryptoGrass", "Magent"],
 	"url": "https://github.com/cryptograss/pickipedia",
 	"descriptionmsg": "pickipediareleases-desc",

--- a/extensions/PickiPediaReleases/extension.json
+++ b/extensions/PickiPediaReleases/extension.json
@@ -48,6 +48,9 @@
 	"MessagesDirs": {
 		"PickiPediaReleases": ["i18n"]
 	},
+	"ExtensionMessagesFiles": {
+		"PickiPediaReleasesAlias": "PickiPediaReleases.alias.php"
+	},
 	"ResourceModules": {
 		"ext.pickipediaReleases.styles": {
 			"styles": ["ext.pickipediaReleases.css"]

--- a/extensions/PickiPediaReleases/extension.json
+++ b/extensions/PickiPediaReleases/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "PickiPediaReleases",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"author": ["CryptoGrass", "Magent"],
 	"url": "https://github.com/cryptograss/pickipedia",
 	"descriptionmsg": "pickipediareleases-desc",
@@ -23,10 +23,22 @@
 			"id": 3005,
 			"constant": "NS_RELEASE_TALK",
 			"name": "Release_talk"
+		},
+		{
+			"id": 3006,
+			"constant": "NS_RELEASEDRAFT",
+			"name": "ReleaseDraft",
+			"defaultcontentmodel": "release-draft-yaml"
+		},
+		{
+			"id": 3007,
+			"constant": "NS_RELEASEDRAFT_TALK",
+			"name": "ReleaseDraft_talk"
 		}
 	],
 	"ContentHandlers": {
-		"release-yaml": "MediaWiki\\Extension\\PickiPediaReleases\\ReleaseContentHandler"
+		"release-yaml": "MediaWiki\\Extension\\PickiPediaReleases\\ReleaseContentHandler",
+		"release-draft-yaml": "MediaWiki\\Extension\\PickiPediaReleases\\ReleaseDraftContentHandler"
 	},
 	"SpecialPages": {
 		"Releases": "MediaWiki\\Extension\\PickiPediaReleases\\SpecialReleases",
@@ -44,7 +56,8 @@
 		}
 	},
 	"Hooks": {
-		"LoadExtensionSchemaUpdates": "main"
+		"LoadExtensionSchemaUpdates": "main",
+		"BeforePageDisplay": "main"
 	},
 	"MessagesDirs": {
 		"PickiPediaReleases": ["i18n"]
@@ -65,7 +78,12 @@
 		},
 		"ext.pickipediaReleases.uploadAlbum": {
 			"scripts": ["ext.pickipediaReleases.uploadAlbum.js"],
-			"dependencies": ["mediawiki.util"]
+			"dependencies": ["mediawiki.util", "mediawiki.api"]
+		},
+		"ext.pickipediaReleases.releaseDraft": {
+			"scripts": ["ext.pickipediaReleases.releaseDraft.js"],
+			"styles": ["ext.pickipediaReleases.releaseDraft.css"],
+			"dependencies": ["mediawiki.util", "mediawiki.api"]
 		}
 	},
 	"ResourceFileModulePaths": {
@@ -77,6 +95,9 @@
 	],
 	"GroupPermissions": {
 		"sysop": {
+			"upload-to-delivery-kid": true
+		},
+		"release": {
 			"upload-to-delivery-kid": true
 		}
 	},

--- a/extensions/PickiPediaReleases/extension.json
+++ b/extensions/PickiPediaReleases/extension.json
@@ -55,13 +55,25 @@
 		"ext.pickipediaReleases.styles": {
 			"styles": ["ext.pickipediaReleases.css"]
 		},
-"ext.pickipediaReleases.upload.styles": {
+		"ext.pickipediaReleases.upload.styles": {
 			"styles": ["ext.pickipediaReleases.upload.css"]
+		},
+		"ext.pickipediaReleases.upload": {
+			"scripts": ["ext.pickipediaReleases.upload.js"],
+			"dependencies": ["mediawiki.util"]
 		}
 	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "resources",
 		"remoteExtPath": "PickiPediaReleases/resources"
+	},
+	"AvailableRights": [
+		"upload-to-delivery-kid"
+	],
+	"GroupPermissions": {
+		"sysop": {
+			"upload-to-delivery-kid": true
+		}
 	},
 	"config": {
 		"DeliveryKidUrl": {

--- a/extensions/PickiPediaReleases/extension.json
+++ b/extensions/PickiPediaReleases/extension.json
@@ -30,7 +30,8 @@
 	},
 	"SpecialPages": {
 		"Releases": "MediaWiki\\Extension\\PickiPediaReleases\\SpecialReleases",
-		"UploadContent": "MediaWiki\\Extension\\PickiPediaReleases\\SpecialUploadContent"
+		"UploadContent": "MediaWiki\\Extension\\PickiPediaReleases\\SpecialUploadContent",
+		"UploadAlbum": "MediaWiki\\Extension\\PickiPediaReleases\\SpecialUploadAlbum"
 	},
 	"APIModules": {
 		"releaselist": {
@@ -60,6 +61,10 @@
 		},
 		"ext.pickipediaReleases.upload": {
 			"scripts": ["ext.pickipediaReleases.upload.js"],
+			"dependencies": ["mediawiki.util"]
+		},
+		"ext.pickipediaReleases.uploadAlbum": {
+			"scripts": ["ext.pickipediaReleases.uploadAlbum.js"],
 			"dependencies": ["mediawiki.util"]
 		}
 	},

--- a/extensions/PickiPediaReleases/i18n/en.json
+++ b/extensions/PickiPediaReleases/i18n/en.json
@@ -15,5 +15,7 @@
 	"special-releases-header": "",
 	"special-releases-mid": "",
 	"special-releases-footer": "",
-	"releases": "Releases"
+	"releases": "Releases",
+	"uploadcontent": "Upload Content",
+	"special-uploadcontent-header": ""
 }

--- a/extensions/PickiPediaReleases/i18n/en.json
+++ b/extensions/PickiPediaReleases/i18n/en.json
@@ -17,5 +17,7 @@
 	"special-releases-footer": "",
 	"releases": "Releases",
 	"uploadcontent": "Upload Content",
-	"special-uploadcontent-header": ""
+	"special-uploadcontent-header": "",
+	"uploadalbum": "Upload Album",
+	"special-uploadalbum-header": ""
 }

--- a/extensions/PickiPediaReleases/i18n/en.json
+++ b/extensions/PickiPediaReleases/i18n/en.json
@@ -19,5 +19,7 @@
 	"uploadcontent": "Upload Content",
 	"special-uploadcontent-header": "",
 	"uploadalbum": "Upload Album",
-	"special-uploadalbum-header": ""
+	"special-uploadalbum-header": "",
+	"action-upload-to-delivery-kid": "upload content to the delivery-kid pinning service",
+	"right-upload-to-delivery-kid": "Upload content directly to the delivery-kid IPFS pinning service"
 }

--- a/extensions/PickiPediaReleases/i18n/en.json
+++ b/extensions/PickiPediaReleases/i18n/en.json
@@ -21,5 +21,8 @@
 	"uploadalbum": "Upload Album",
 	"special-uploadalbum-header": "",
 	"action-upload-to-delivery-kid": "upload content to the delivery-kid pinning service",
-	"right-upload-to-delivery-kid": "Upload content directly to the delivery-kid IPFS pinning service"
+	"right-upload-to-delivery-kid": "Upload content directly to the delivery-kid IPFS pinning service",
+	"releasedraft-missing-draft-id": "Release draft is missing a draft_id field.",
+	"releasedraft-missing-type": "Release draft is missing a type field.",
+	"release-draft-yaml-desc": "YAML metadata for release drafts"
 }

--- a/extensions/PickiPediaReleases/i18n/en.json
+++ b/extensions/PickiPediaReleases/i18n/en.json
@@ -12,5 +12,8 @@
 	"apihelp-releaselist-example-ipfs": "List releases with IPFS CIDs",
 	"special-releases": "Releases",
 	"special-releases-summary": "All releases in the catalog",
+	"special-releases-header": "",
+	"special-releases-mid": "",
+	"special-releases-footer": "",
 	"releases": "Releases"
 }

--- a/extensions/PickiPediaReleases/i18n/en.json
+++ b/extensions/PickiPediaReleases/i18n/en.json
@@ -11,5 +11,6 @@
 	"apihelp-releaselist-example-all": "List all releases",
 	"apihelp-releaselist-example-ipfs": "List releases with IPFS CIDs",
 	"special-releases": "Releases",
-	"special-releases-summary": "All releases in the catalog"
+	"special-releases-summary": "All releases in the catalog",
+	"releases": "Releases"
 }

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -147,6 +147,28 @@
 	flex-wrap: wrap;
 }
 
+/* Save button states */
+#rd-save-btn {
+	transition: background-color 0.3s, border-color 0.3s;
+}
+
+#rd-save-btn.rd-saving {
+	opacity: 0.7;
+	cursor: wait;
+}
+
+#rd-save-btn.rd-saved {
+	background-color: #14866d;
+	border-color: #14866d;
+	color: #fff;
+}
+
+#rd-save-btn.rd-save-failed {
+	background-color: #d33;
+	border-color: #d33;
+	color: #fff;
+}
+
 /* Album form */
 .rd-album-form {
 	margin-bottom: 1em;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -1,0 +1,172 @@
+/**
+ * Styles for ReleaseDraft namespace pages.
+ */
+
+/* Status banners */
+.rd-status-banner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.75em 1em;
+	margin-bottom: 1.5em;
+	border-radius: 4px;
+	font-size: 0.95em;
+}
+
+.rd-status-draft {
+	background: #eaf3ff;
+	border: 1px solid #36c;
+	color: #36c;
+}
+
+.rd-status-finalizing {
+	background: #fef6e7;
+	border: 1px solid #ac6600;
+	color: #ac6600;
+}
+
+.rd-status-complete {
+	background: #d5fdf4;
+	border: 1px solid #14866d;
+	color: #14866d;
+}
+
+.rd-status-label {
+	font-weight: bold;
+}
+
+.rd-status-type {
+	font-size: 0.85em;
+	opacity: 0.8;
+}
+
+/* Track list */
+.rd-track-list {
+	margin: 0.5em 0 1.5em;
+}
+
+.rd-track-row {
+	display: flex;
+	align-items: flex-start;
+	padding: 0.6em 0.75em;
+	margin: 0.3em 0;
+	background: #fff;
+	border: 1px solid #c8ccd1;
+	border-radius: 3px;
+	gap: 0.5em;
+}
+
+.rd-track-row[draggable="true"] {
+	cursor: grab;
+}
+
+.rd-track-row.rd-track-dragging {
+	opacity: 0.4;
+}
+
+.rd-track-num {
+	font-weight: bold;
+	min-width: 1.5em;
+	text-align: center;
+	color: #54595d;
+	padding-top: 0.3em;
+}
+
+.rd-track-info {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.4em;
+}
+
+.rd-track-title {
+	width: 100%;
+}
+
+.rd-track-meta {
+	font-size: 0.8em;
+	color: #72777d;
+}
+
+.rd-track-metadata {
+	width: 100%;
+	font-family: monospace;
+	font-size: 0.85em;
+	resize: vertical;
+	min-height: 2.5em;
+}
+
+/* Blockheight section */
+.rd-blockheight-section {
+	margin: 1.5em 0;
+	padding-top: 1em;
+	border-top: 1px solid #eaecf0;
+}
+
+.rd-blockheight-row {
+	display: flex;
+	align-items: center;
+	gap: 0.75em;
+	flex-wrap: wrap;
+}
+
+.rd-blockheight-input {
+	max-width: 200px;
+}
+
+.rd-blockheight-date {
+	font-size: 0.9em;
+	color: #54595d;
+	font-style: italic;
+}
+
+.rd-date-converter {
+	margin-top: 0.5em;
+}
+
+.rd-date-converter label {
+	font-weight: normal;
+	font-size: 0.9em;
+	color: #72777d;
+	margin-right: 0.5em;
+}
+
+.rd-date-input {
+	max-width: 200px;
+}
+
+/* Action buttons */
+.rd-actions {
+	margin: 1.5em 0;
+	padding-top: 1em;
+	border-top: 1px solid #eaecf0;
+	display: flex;
+	align-items: center;
+	gap: 0.75em;
+	flex-wrap: wrap;
+}
+
+/* Album form */
+.rd-album-form {
+	margin-bottom: 1em;
+}
+
+/* Raw YAML toggle */
+.release-raw-yaml {
+	margin-top: 2em;
+	font-size: 0.9em;
+}
+
+.release-raw-yaml summary {
+	cursor: pointer;
+	color: #72777d;
+}
+
+.release-raw-yaml pre {
+	background: #f8f9fa;
+	border: 1px solid #eaecf0;
+	padding: 0.75em;
+	overflow-x: auto;
+	font-size: 0.85em;
+}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -169,6 +169,85 @@
 	color: #fff;
 }
 
+/* Finalize progress */
+.rd-finalize-progress {
+	margin-top: 1em;
+	padding: 1em;
+	background: #f8f9fa;
+	border: 1px solid #c8ccd1;
+	border-radius: 4px;
+}
+
+.rd-stages {
+	display: flex;
+	gap: 0;
+	margin-bottom: 1em;
+}
+
+.rd-stage {
+	flex: 1;
+	text-align: center;
+	padding: 0.5em 0.25em;
+	font-size: 0.85em;
+	color: #72777d;
+	background: #eaecf0;
+	border-right: 1px solid #c8ccd1;
+	position: relative;
+}
+
+.rd-stage:first-child {
+	border-radius: 3px 0 0 3px;
+}
+
+.rd-stage:last-child {
+	border-radius: 0 3px 3px 0;
+	border-right: none;
+}
+
+.rd-stage.rd-stage-active {
+	background: #36c;
+	color: #fff;
+	font-weight: bold;
+}
+
+.rd-stage.rd-stage-done {
+	background: #14866d;
+	color: #fff;
+}
+
+.rd-stage.rd-stage-error {
+	background: #d33;
+	color: #fff;
+}
+
+.rd-progress-status {
+	margin: 0.75em 0 0.25em;
+	font-size: 0.95em;
+	font-weight: bold;
+}
+
+.rd-progress-status.rd-status-error {
+	color: #d33;
+}
+
+.rd-progress-status.rd-status-success {
+	color: #14866d;
+}
+
+.rd-progress-log {
+	font-size: 0.85em;
+	color: #54595d;
+	max-height: 8em;
+	overflow-y: auto;
+	font-family: monospace;
+	line-height: 1.6;
+}
+
+.rd-progress-log div {
+	padding: 0.1em 0;
+	border-bottom: 1px solid #eaecf0;
+}
+
 /* Album form */
 .rd-album-form {
 	margin-bottom: 1em;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -105,7 +105,7 @@
 		// Album fields
 		var titleEl = el( 'rd-album-title' );
 		var artistEl = el( 'rd-artist' );
-		var yearEl = el( 'rd-year' );
+		var versionEl = el( 'rd-version' );
 		var descEl = el( 'rd-description' );
 
 		if ( !data.album ) {
@@ -117,8 +117,8 @@
 		if ( artistEl ) {
 			data.album.artist = artistEl.value;
 		}
-		if ( yearEl ) {
-			data.album.year = yearEl.value;
+		if ( versionEl ) {
+			data.album.version = versionEl.value;
 		}
 		if ( descEl ) {
 			data.album.description = descEl.value;
@@ -210,7 +210,7 @@
 		var album = data.album || {};
 		lines.push( '    title: ' + quote( album.title || '' ) );
 		lines.push( '    artist: ' + quote( album.artist || '' ) );
-		lines.push( '    year: ' + quote( album.year || '' ) );
+		lines.push( '    version: ' + quote( album.version || '' ) );
 		lines.push( '    description: ' + quote( album.description || '' ) );
 
 		// Tracks
@@ -325,7 +325,6 @@
 			var body = JSON.stringify( {
 				album_title: album.title,
 				artist: album.artist,
-				year: album.year || null,
 				description: album.description || null,
 				tracks: tracks
 			} );
@@ -486,7 +485,8 @@
 					if ( resp.result ) {
 						var blockNum = parseInt( resp.result, 16 );
 						bhInput.value = blockNum;
-						updateBlockDate( blockNum );
+						// We just fetched the current block, so the date is now
+						setBlockDateToNow();
 					}
 				} )
 				.catch( function () {
@@ -549,6 +549,19 @@
 			return MERGE_BLOCK + Math.floor( ( ts - MERGE_TS ) / POST_MERGE_BLOCK_TIME );
 		}
 		return Math.floor( ( ts - ETH_GENESIS_TS ) / PRE_MERGE_AVG );
+	}
+
+	function setBlockDateToNow() {
+		var dateLabel = el( 'rd-blockheight-date' );
+		if ( !dateLabel ) {
+			return;
+		}
+		var date = new Date();
+		dateLabel.textContent = '≈ ' + date.toLocaleDateString( 'en-US', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric'
+		} );
 	}
 
 	function updateBlockDate( blockNumber ) {

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -474,11 +474,60 @@
 			text: yaml,
 			summary: 'Finalized: pinned to IPFS as ' + ( resultData.cid || 'unknown' )
 		} ).then( function () {
-			setStatus( 'Saved! Reloading...', 'success' );
-			window.location.reload();
+			setStatus( 'Draft saved. Creating Release page...', 'success' );
+			return createReleasePage( data, resultData );
+		} ).then( function () {
+			setStatus( 'Done! Redirecting to Release page...', 'success' );
+			window.location.href = mw.util.getUrl( 'Release:' + resultData.cid );
 		} ).fail( function ( code, result ) {
-			setStatus( 'Pinned to IPFS but failed to save page: ' +
+			setStatus( 'Pinned to IPFS but failed to save: ' +
 				( result.error ? result.error.info : code ) + '. CID: ' + resultData.cid, 'error' );
+		} );
+	}
+
+	function createReleasePage( draftData, resultData ) {
+		var cid = resultData.cid;
+		if ( !cid ) {
+			return $.Deferred().resolve().promise();
+		}
+
+		var album = draftData.album || {};
+		var lines = [];
+
+		// Build release-yaml content
+		var title = album.artist && album.title
+			? album.artist + ' - ' + album.title
+			: album.title || '';
+		if ( album.version ) {
+			title += ' (' + album.version + ')';
+		}
+		lines.push( 'title: ' + quote( title ) );
+
+		if ( album.description ) {
+			lines.push( 'description: ' + quote( album.description ) );
+		}
+
+		if ( draftData.blockheight ) {
+			lines.push( 'blockheight: ' + draftData.blockheight );
+		}
+
+		lines.push( 'pinned_on:' );
+		lines.push( '  - delivery-kid' );
+
+		var releaseYaml = lines.join( '\n' ) + '\n';
+
+		var api = new mw.Api();
+		return api.postWithEditToken( {
+			action: 'edit',
+			title: 'Release:' + cid,
+			text: releaseYaml,
+			summary: 'Release created from draft: ' + ( album.title || cid ),
+			createonly: true
+		} ).fail( function ( code ) {
+			// If page already exists, that's fine
+			if ( code === 'articleexists' ) {
+				return $.Deferred().resolve().promise();
+			}
 		} );
 	}
 

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -35,7 +35,7 @@
 			return;
 		}
 		statusEl.textContent = msg;
-		statusEl.className = 'uc-status' + ( type ? ' uc-status-' + type : '' );
+		statusEl.className = 'rd-progress-status' + ( type ? ' rd-status-' + type : '' );
 	}
 
 	// -- Track drag reorder --
@@ -330,7 +330,9 @@
 				progressDiv.style.display = '';
 			}
 			setProgress( 0 );
+			setActiveStage( 'preparing' );
 			setStatus( 'Starting finalization...', '' );
+			appendLog( 'Sending finalize request to delivery-kid...' );
 
 			// Build track order with per-track metadata
 			var tracks = ( data.tracks || [] ).map( function ( t ) {
@@ -392,7 +394,9 @@
 		if ( progressDiv ) {
 			progressDiv.style.display = '';
 		}
+		setStageError();
 		setStatus( msg, 'error' );
+		appendLog( 'ERROR: ' + msg );
 	}
 
 	function readSSEStream( resp ) {
@@ -435,19 +439,33 @@
 	function handleSSEEvent( event, data ) {
 		if ( event === 'progress' ) {
 			setProgress( data.progress || 0 );
+
+			// Detect stage from message content
 			var msg = data.message || '';
-			if ( data.track ) {
-				msg += ' (' + data.track + ')';
+			var stage = data.stage || detectStage( msg );
+			if ( stage ) {
+				setActiveStage( stage );
 			}
-			setStatus( msg, '' );
+
+			var logMsg = msg;
+			if ( data.track ) {
+				logMsg += ' — ' + data.track;
+			}
+			setStatus( logMsg, '' );
+			appendLog( logMsg );
 		} else if ( event === 'warning' ) {
-			setStatus( 'Warning: ' + data.message, 'warning' );
+			setStatus( 'Warning: ' + data.message, '' );
+			appendLog( '⚠ ' + data.message );
 		} else if ( event === 'complete' ) {
 			setProgress( 100 );
+			setActiveStage( 'complete' );
 			setStatus( 'Album pinned to IPFS!', 'success' );
+			appendLog( 'CID: ' + ( data.cid || 'unknown' ) );
 			saveResultToPage( data );
 		} else if ( event === 'error' ) {
+			setStageError();
 			showFinalizeError( 'Error: ' + ( data.message || 'Unknown error' ) );
+			appendLog( 'ERROR: ' + ( data.message || 'Unknown error' ) );
 			var finalizeBtn = el( 'rd-finalize-btn' );
 			var saveBtn = el( 'rd-save-btn' );
 			if ( finalizeBtn ) {
@@ -459,11 +477,63 @@
 		}
 	}
 
+	function detectStage( msg ) {
+		var lower = msg.toLowerCase();
+		if ( /transcod/.test( lower ) ) {
+			return 'transcoding';
+		}
+		if ( /tag/.test( lower ) || /vorbis/.test( lower ) || /metadata/.test( lower ) ) {
+			return 'tagging';
+		}
+		if ( /pin/.test( lower ) || /upload/.test( lower ) || /ipfs/.test( lower ) ) {
+			return 'pinning';
+		}
+		if ( /prepar/.test( lower ) || /start/.test( lower ) || /validat/.test( lower ) ) {
+			return 'preparing';
+		}
+		return null;
+	}
+
+	function setActiveStage( stageName ) {
+		var stages = document.querySelectorAll( '.rd-stage' );
+		var reached = false;
+		var passed = false;
+		stages.forEach( function ( stageEl ) {
+			var key = stageEl.dataset.stage;
+			stageEl.classList.remove( 'rd-stage-active', 'rd-stage-done', 'rd-stage-error' );
+			if ( key === stageName ) {
+				stageEl.classList.add( 'rd-stage-active' );
+				reached = true;
+			} else if ( !reached ) {
+				stageEl.classList.add( 'rd-stage-done' );
+			}
+		} );
+	}
+
+	function setStageError() {
+		var active = document.querySelector( '.rd-stage.rd-stage-active' );
+		if ( active ) {
+			active.classList.remove( 'rd-stage-active' );
+			active.classList.add( 'rd-stage-error' );
+		}
+	}
+
 	function setProgress( pct ) {
 		var fill = document.querySelector( '#rd-progress-bar .uc-progress-fill' );
 		if ( fill ) {
 			fill.style.width = pct + '%';
 		}
+	}
+
+	function appendLog( msg ) {
+		var log = el( 'rd-progress-log' );
+		if ( !log ) {
+			return;
+		}
+		var line = document.createElement( 'div' );
+		line.textContent = msg;
+		log.appendChild( line );
+		log.scrollTop = log.scrollHeight;
 	}
 
 	function saveResultToPage( resultData ) {

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -1,0 +1,579 @@
+/**
+ * ReleaseDraft interactive form — JS for the ReleaseDraft namespace.
+ *
+ * Reads draft data from mw.config.get('wgReleaseDraftData'),
+ * provides:
+ * - Track drag-and-drop reorder
+ * - Save button: collect form data → YAML → MediaWiki edit API
+ * - Finalize button: send to delivery-kid /draft-album/{id}/finalize (SSE)
+ * - Blockheight date converter (Etherscan API)
+ */
+( function () {
+	'use strict';
+
+	var draftData = mw.config.get( 'wgReleaseDraftData' ) || {};
+
+	// Blockheight estimation using a known reference point (more accurate than genesis)
+	// The Merge (block 15537394) happened at 2022-09-15T06:42:42Z
+	// Post-merge block time is exactly 12 seconds
+	var MERGE_BLOCK = 15537394;
+	var MERGE_TS = 1663220562; // 2022-09-15T06:42:42Z
+	var POST_MERGE_BLOCK_TIME = 12; // exactly 12 seconds post-merge
+	// Pre-merge: genesis to merge, ~13.3s average
+	var ETH_GENESIS_TS = 1438269973;
+	var PRE_MERGE_AVG = 13.3;
+
+	// -- Helpers --
+
+	function el( id ) {
+		return document.getElementById( id );
+	}
+
+	function setStatus( msg, type ) {
+		var statusEl = el( 'rd-progress-status' );
+		if ( !statusEl ) {
+			return;
+		}
+		statusEl.textContent = msg;
+		statusEl.className = 'uc-status' + ( type ? ' uc-status-' + type : '' );
+	}
+
+	// -- Track drag reorder --
+
+	function initTrackDragReorder() {
+		var container = el( 'rd-track-list' );
+		if ( !container ) {
+			return;
+		}
+
+		var dragSrc = null;
+
+		container.addEventListener( 'dragstart', function ( e ) {
+			var row = e.target.closest( '.rd-track-row' );
+			if ( !row || row.getAttribute( 'draggable' ) === 'false' ) {
+				return;
+			}
+			dragSrc = row;
+			row.classList.add( 'rd-track-dragging' );
+			e.dataTransfer.effectAllowed = 'move';
+		} );
+
+		container.addEventListener( 'dragover', function ( e ) {
+			e.preventDefault();
+			e.dataTransfer.dropEffect = 'move';
+			var row = e.target.closest( '.rd-track-row' );
+			if ( row && row !== dragSrc ) {
+				var rect = row.getBoundingClientRect();
+				var midY = rect.top + rect.height / 2;
+				if ( e.clientY < midY ) {
+					container.insertBefore( dragSrc, row );
+				} else {
+					container.insertBefore( dragSrc, row.nextSibling );
+				}
+			}
+		} );
+
+		container.addEventListener( 'dragend', function () {
+			if ( dragSrc ) {
+				dragSrc.classList.remove( 'rd-track-dragging' );
+				dragSrc = null;
+			}
+			renumberTracks();
+		} );
+	}
+
+	function renumberTracks() {
+		var container = el( 'rd-track-list' );
+		if ( !container ) {
+			return;
+		}
+		var rows = container.querySelectorAll( '.rd-track-row' );
+		rows.forEach( function ( row, idx ) {
+			row.dataset.idx = idx;
+			var num = row.querySelector( '.rd-track-num' );
+			if ( num ) {
+				num.textContent = idx + 1;
+			}
+		} );
+	}
+
+	// -- Collect form data --
+
+	function collectFormData() {
+		var data = JSON.parse( JSON.stringify( draftData ) );
+
+		// Album fields
+		var titleEl = el( 'rd-album-title' );
+		var artistEl = el( 'rd-artist' );
+		var yearEl = el( 'rd-year' );
+		var descEl = el( 'rd-description' );
+
+		if ( !data.album ) {
+			data.album = {};
+		}
+		if ( titleEl ) {
+			data.album.title = titleEl.value;
+		}
+		if ( artistEl ) {
+			data.album.artist = artistEl.value;
+		}
+		if ( yearEl ) {
+			data.album.year = yearEl.value;
+		}
+		if ( descEl ) {
+			data.album.description = descEl.value;
+		}
+
+		// Tracks — collect in current DOM order (respects drag reorder)
+		var trackRows = document.querySelectorAll( '.rd-track-row' );
+		var tracks = [];
+		trackRows.forEach( function ( row ) {
+			var titleInput = row.querySelector( '.rd-track-title' );
+			var metaTextarea = row.querySelector( '.rd-track-metadata' );
+			var filename = row.dataset.filename || '';
+
+			// Find original track data by filename
+			var original = ( draftData.tracks || [] ).find( function ( t ) {
+				return t.filename === filename;
+			} ) || {};
+
+			tracks.push( {
+				filename: filename,
+				title: titleInput ? titleInput.value : ( original.title || '' ),
+				metadata: metaTextarea ? metaTextarea.value : ( original.metadata || '' ),
+				format: original.format || '',
+				duration: original.duration || null,
+				size_bytes: original.size_bytes || null
+			} );
+		} );
+		data.tracks = tracks;
+
+		// Blockheight
+		var bhEl = el( 'rd-blockheight' );
+		if ( bhEl && bhEl.value.trim() ) {
+			data.blockheight = parseInt( bhEl.value.trim(), 10 ) || null;
+		}
+
+		return data;
+	}
+
+	// -- Save draft via MediaWiki API --
+
+	function initSaveButton() {
+		var saveBtn = el( 'rd-save-btn' );
+		if ( !saveBtn ) {
+			return;
+		}
+
+		saveBtn.addEventListener( 'click', function () {
+			saveBtn.disabled = true;
+			setStatus( 'Saving draft...', '' );
+
+			var data = collectFormData();
+
+			// Serialize to YAML-ish format (simple key-value, MediaWiki will store as-is)
+			var yaml = serializeToYaml( data );
+
+			var api = new mw.Api();
+			api.postWithEditToken( {
+				action: 'edit',
+				title: mw.config.get( 'wgPageName' ),
+				text: yaml,
+				summary: 'Update release draft metadata',
+				minor: true
+			} ).then( function () {
+				setStatus( 'Draft saved.', 'success' );
+				saveBtn.disabled = false;
+			} ).fail( function ( code, result ) {
+				setStatus( 'Save failed: ' + ( result.error ? result.error.info : code ), 'error' );
+				saveBtn.disabled = false;
+			} );
+		} );
+	}
+
+	function serializeToYaml( data ) {
+		// Build YAML manually for clean output (no library dependency)
+		var lines = [];
+
+		lines.push( 'draft_id: ' + quote( data.draft_id || '' ) );
+		lines.push( 'type: ' + quote( data.type || 'album' ) );
+		lines.push( 'status: ' + quote( data.status || 'draft' ) );
+
+		if ( data.blockheight ) {
+			lines.push( 'blockheight: ' + data.blockheight );
+		} else {
+			lines.push( 'blockheight: null' );
+		}
+
+		// Album section
+		lines.push( 'album:' );
+		var album = data.album || {};
+		lines.push( '    title: ' + quote( album.title || '' ) );
+		lines.push( '    artist: ' + quote( album.artist || '' ) );
+		lines.push( '    year: ' + quote( album.year || '' ) );
+		lines.push( '    description: ' + quote( album.description || '' ) );
+
+		// Tracks
+		lines.push( 'tracks:' );
+		( data.tracks || [] ).forEach( function ( track ) {
+			lines.push( '    -' );
+			lines.push( '        filename: ' + quote( track.filename || '' ) );
+			lines.push( '        title: ' + quote( track.title || '' ) );
+			if ( track.format ) {
+				lines.push( '        format: ' + quote( track.format ) );
+			}
+			if ( track.duration ) {
+				lines.push( '        duration: ' + track.duration );
+			}
+			if ( track.size_bytes ) {
+				lines.push( '        size_bytes: ' + track.size_bytes );
+			}
+			if ( track.metadata ) {
+				// Multi-line metadata uses YAML literal block scalar
+				lines.push( '        metadata: |' );
+				track.metadata.split( '\n' ).forEach( function ( ml ) {
+					lines.push( '            ' + ml );
+				} );
+			} else {
+				lines.push( '        metadata: ""' );
+			}
+		} );
+
+		// Result section
+		lines.push( 'result:' );
+		var result = data.result || {};
+		lines.push( '    cid: ' + ( result.cid ? quote( result.cid ) : 'null' ) );
+		lines.push( '    gateway_url: ' + ( result.gateway_url ? quote( result.gateway_url ) : 'null' ) );
+
+		return lines.join( '\n' ) + '\n';
+	}
+
+	function quote( val ) {
+		if ( val === '' || val === null || val === undefined ) {
+			return '""';
+		}
+		val = String( val );
+		// Quote if contains special YAML chars
+		if ( /[:#\[\]{}&*!|>'"%@`\n]/.test( val ) || val.trim() !== val ) {
+			return '"' + val.replace( /\\/g, '\\\\' ).replace( /"/g, '\\"' ).replace( /\n/g, '\\n' ) + '"';
+		}
+		return val;
+	}
+
+	// -- Finalize via delivery-kid --
+
+	function initFinalizeButton() {
+		var finalizeBtn = el( 'rd-finalize-btn' );
+		if ( !finalizeBtn ) {
+			return;
+		}
+
+		finalizeBtn.addEventListener( 'click', function () {
+			var data = collectFormData();
+			var draftId = data.draft_id;
+			if ( !draftId ) {
+				setStatus( 'No draft ID — cannot finalize.', 'error' );
+				return;
+			}
+
+			var album = data.album || {};
+			if ( !album.title ) {
+				setStatus( 'Album title is required to finalize.', 'error' );
+				el( 'rd-album-title' ).focus();
+				return;
+			}
+			if ( !album.artist ) {
+				setStatus( 'Artist is required to finalize.', 'error' );
+				el( 'rd-artist' ).focus();
+				return;
+			}
+
+			if ( !confirm( 'Finalize this album? This will transcode, tag, and pin to IPFS.' ) ) {
+				return;
+			}
+
+			finalizeBtn.disabled = true;
+			el( 'rd-save-btn' ).disabled = true;
+
+			var progressDiv = el( 'rd-finalize-progress' );
+			if ( progressDiv ) {
+				progressDiv.style.display = '';
+			}
+			setProgress( 0 );
+			setStatus( 'Starting finalization...', '' );
+
+			// Build track order with per-track metadata
+			var tracks = ( data.tracks || [] ).map( function ( t ) {
+				return {
+					filename: t.filename,
+					title: t.title,
+					metadata: t.metadata || ''
+				};
+			} );
+
+			var apiUrl = mw.config.get( 'wgDeliveryKidUrl' );
+			var authHeaders = {
+				'X-Upload-Token': mw.config.get( 'wgUploadToken' ),
+				'X-Upload-User': mw.config.get( 'wgUploadUser' ),
+				'X-Upload-Timestamp': String( mw.config.get( 'wgUploadTimestamp' ) )
+			};
+
+			var headers = Object.assign( {}, authHeaders, {
+				'Content-Type': 'application/json'
+			} );
+
+			var body = JSON.stringify( {
+				album_title: album.title,
+				artist: album.artist,
+				year: album.year || null,
+				description: album.description || null,
+				tracks: tracks
+			} );
+
+			fetch( apiUrl + '/draft-album/' + draftId + '/finalize', {
+				method: 'POST',
+				headers: headers,
+				body: body
+			} ).then( function ( resp ) {
+				if ( !resp.ok ) {
+					return resp.json().then( function ( err ) {
+						var detail = err.detail;
+						var msg;
+						if ( typeof detail === 'string' ) {
+							msg = detail;
+						} else if ( detail && detail.error ) {
+							msg = detail.error;
+						} else {
+							msg = JSON.stringify( err );
+						}
+						throw new Error( msg );
+					} );
+				}
+				return readSSEStream( resp );
+			} ).catch( function ( err ) {
+				setStatus( 'Finalization error: ' + err.message, 'error' );
+				finalizeBtn.disabled = false;
+				el( 'rd-save-btn' ).disabled = false;
+			} );
+		} );
+	}
+
+	function readSSEStream( resp ) {
+		var reader = resp.body.getReader();
+		var decoder = new TextDecoder();
+		var buffer = '';
+
+		function pump() {
+			return reader.read().then( function ( result ) {
+				if ( result.done ) {
+					return;
+				}
+
+				buffer += decoder.decode( result.value, { stream: true } );
+				var lines = buffer.split( '\n' );
+				buffer = lines.pop();
+
+				var currentEvent = '';
+				for ( var i = 0; i < lines.length; i++ ) {
+					var line = lines[ i ].trim();
+					if ( line.indexOf( 'event:' ) === 0 ) {
+						currentEvent = line.slice( 6 ).trim();
+					} else if ( line.indexOf( 'data:' ) === 0 ) {
+						var sseData = line.slice( 5 ).trim();
+						try {
+							handleSSEEvent( currentEvent, JSON.parse( sseData ) );
+						} catch ( e ) {
+							// skip malformed
+						}
+					}
+				}
+
+				return pump();
+			} );
+		}
+
+		return pump();
+	}
+
+	function handleSSEEvent( event, data ) {
+		if ( event === 'progress' ) {
+			setProgress( data.progress || 0 );
+			var msg = data.message || '';
+			if ( data.track ) {
+				msg += ' (' + data.track + ')';
+			}
+			setStatus( msg, '' );
+		} else if ( event === 'warning' ) {
+			setStatus( 'Warning: ' + data.message, 'warning' );
+		} else if ( event === 'complete' ) {
+			setProgress( 100 );
+			setStatus( 'Album pinned to IPFS!', 'success' );
+			saveResultToPage( data );
+		} else if ( event === 'error' ) {
+			setStatus( 'Error: ' + ( data.message || 'Unknown error' ), 'error' );
+			var finalizeBtn = el( 'rd-finalize-btn' );
+			var saveBtn = el( 'rd-save-btn' );
+			if ( finalizeBtn ) {
+				finalizeBtn.disabled = false;
+			}
+			if ( saveBtn ) {
+				saveBtn.disabled = false;
+			}
+		}
+	}
+
+	function setProgress( pct ) {
+		var fill = document.querySelector( '#rd-progress-bar .uc-progress-fill' );
+		if ( fill ) {
+			fill.style.width = pct + '%';
+		}
+	}
+
+	function saveResultToPage( resultData ) {
+		// Update local data with result, change status to complete
+		var data = collectFormData();
+		data.status = 'complete';
+		data.result = {
+			cid: resultData.cid || null,
+			gateway_url: resultData.gateway_url || null
+		};
+
+		var yaml = serializeToYaml( data );
+		var api = new mw.Api();
+		api.postWithEditToken( {
+			action: 'edit',
+			title: mw.config.get( 'wgPageName' ),
+			text: yaml,
+			summary: 'Finalized: pinned to IPFS as ' + ( resultData.cid || 'unknown' )
+		} ).then( function () {
+			setStatus( 'Saved! Reloading...', 'success' );
+			window.location.reload();
+		} ).fail( function ( code, result ) {
+			setStatus( 'Pinned to IPFS but failed to save page: ' +
+				( result.error ? result.error.info : code ) + '. CID: ' + resultData.cid, 'error' );
+		} );
+	}
+
+	// -- Blockheight converter --
+
+	function initBlockheightConverter() {
+		var nowBtn = el( 'rd-blockheight-now' );
+		var bhInput = el( 'rd-blockheight' );
+		var dateLabel = el( 'rd-blockheight-date' );
+		var dateInput = el( 'rd-date-input' );
+
+		if ( !nowBtn || !bhInput ) {
+			return;
+		}
+
+		// "Current Block" button — fetch latest via public Ethereum RPC
+		nowBtn.addEventListener( 'click', function () {
+			nowBtn.disabled = true;
+			nowBtn.textContent = 'Fetching...';
+
+			fetch( 'https://ethereum-rpc.publicnode.com', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify( {
+					jsonrpc: '2.0',
+					method: 'eth_blockNumber',
+					params: [],
+					id: 1
+				} )
+			} )
+				.then( function ( r ) { return r.json(); } )
+				.then( function ( resp ) {
+					if ( resp.result ) {
+						var blockNum = parseInt( resp.result, 16 );
+						bhInput.value = blockNum;
+						updateBlockDate( blockNum );
+					}
+				} )
+				.catch( function () {
+					// Fallback: estimate from current time
+					var now = Math.floor( Date.now() / 1000 );
+					var estimated = timestampToBlock( now );
+					bhInput.value = estimated;
+					updateBlockDate( estimated );
+				} )
+				.finally( function () {
+					nowBtn.disabled = false;
+					nowBtn.textContent = 'Current Block';
+				} );
+		} );
+
+		// When user types a block number, estimate the date
+		bhInput.addEventListener( 'change', function () {
+			var val = parseInt( bhInput.value, 10 );
+			if ( val > 0 ) {
+				updateBlockDate( val );
+			} else if ( dateLabel ) {
+				dateLabel.textContent = '';
+			}
+		} );
+
+		// Date picker → estimate block number
+		if ( dateInput ) {
+			dateInput.addEventListener( 'change', function () {
+				var dateStr = dateInput.value;
+				if ( !dateStr ) {
+					return;
+				}
+				var ts = Math.floor( new Date( dateStr + 'T12:00:00Z' ).getTime() / 1000 );
+				var estimated = timestampToBlock( ts );
+				if ( estimated > 0 ) {
+					bhInput.value = estimated;
+					updateBlockDate( estimated );
+				}
+			} );
+		}
+
+		// Show date for existing value on load
+		var existingVal = parseInt( bhInput.value, 10 );
+		if ( existingVal > 0 ) {
+			updateBlockDate( existingVal );
+		}
+	}
+
+	function blockToTimestamp( blockNumber ) {
+		if ( blockNumber >= MERGE_BLOCK ) {
+			// Post-merge: exactly 12s per block from the merge point
+			return MERGE_TS + ( ( blockNumber - MERGE_BLOCK ) * POST_MERGE_BLOCK_TIME );
+		}
+		// Pre-merge: estimate from genesis with ~13.3s average
+		return ETH_GENESIS_TS + ( blockNumber * PRE_MERGE_AVG );
+	}
+
+	function timestampToBlock( ts ) {
+		if ( ts >= MERGE_TS ) {
+			return MERGE_BLOCK + Math.floor( ( ts - MERGE_TS ) / POST_MERGE_BLOCK_TIME );
+		}
+		return Math.floor( ( ts - ETH_GENESIS_TS ) / PRE_MERGE_AVG );
+	}
+
+	function updateBlockDate( blockNumber ) {
+		var dateLabel = el( 'rd-blockheight-date' );
+		if ( !dateLabel ) {
+			return;
+		}
+		var estimatedTs = blockToTimestamp( blockNumber );
+		var date = new Date( estimatedTs * 1000 );
+		dateLabel.textContent = '≈ ' + date.toLocaleDateString( 'en-US', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric'
+		} );
+	}
+
+	// -- Init --
+
+	function init() {
+		initTrackDragReorder();
+		initSaveButton();
+		initFinalizeButton();
+		initBlockheightConverter();
+	}
+
+	mw.loader.using( [ 'mediawiki.util', 'mediawiki.api' ] ).then( init );
+
+}() );

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -283,6 +283,15 @@
 			return;
 		}
 
+		// Hide action buttons for logged-out users
+		if ( mw.config.get( 'wgUserId' ) === null ) {
+			var actionsDiv = el( 'rd-actions' );
+			if ( actionsDiv ) {
+				actionsDiv.innerHTML = '<p class="uc-status uc-status-error">You must be logged in to save or finalize drafts.</p>';
+			}
+			return;
+		}
+
 		finalizeBtn.addEventListener( 'click', function () {
 			var data = collectFormData();
 			var draftId = data.draft_id;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -166,8 +166,10 @@
 		}
 
 		saveBtn.addEventListener( 'click', function () {
+			var originalText = saveBtn.textContent;
 			saveBtn.disabled = true;
-			setStatus( 'Saving draft...', '' );
+			saveBtn.textContent = 'Saving...';
+			saveBtn.classList.add( 'rd-saving' );
 
 			var data = collectFormData();
 
@@ -182,11 +184,24 @@
 				summary: 'Update release draft metadata',
 				minor: true
 			} ).then( function () {
-				setStatus( 'Draft saved.', 'success' );
-				saveBtn.disabled = false;
+				saveBtn.textContent = 'Saved!';
+				saveBtn.classList.remove( 'rd-saving' );
+				saveBtn.classList.add( 'rd-saved' );
+				setTimeout( function () {
+					saveBtn.textContent = originalText;
+					saveBtn.classList.remove( 'rd-saved' );
+					saveBtn.disabled = false;
+				}, 2000 );
 			} ).fail( function ( code, result ) {
+				saveBtn.textContent = 'Save Failed';
+				saveBtn.classList.remove( 'rd-saving' );
+				saveBtn.classList.add( 'rd-save-failed' );
 				setStatus( 'Save failed: ' + ( result.error ? result.error.info : code ), 'error' );
-				saveBtn.disabled = false;
+				setTimeout( function () {
+					saveBtn.textContent = originalText;
+					saveBtn.classList.remove( 'rd-save-failed' );
+					saveBtn.disabled = false;
+				}, 3000 );
 			} );
 		} );
 	}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -485,9 +485,6 @@
 		if ( /tag/.test( lower ) || /vorbis/.test( lower ) || /metadata/.test( lower ) ) {
 			return 'tagging';
 		}
-		if ( /torrent|infohash|magnet/.test( lower ) ) {
-			return 'torrenting';
-		}
 		if ( /pin/.test( lower ) || /upload/.test( lower ) || /ipfs/.test( lower ) ) {
 			return 'pinning';
 		}
@@ -595,17 +592,6 @@
 
 		lines.push( 'pinned_on:' );
 		lines.push( '  - delivery-kid' );
-
-		// BitTorrent fields from finalize result
-		if ( resultData.bittorrent_infohash ) {
-			lines.push( 'bittorrent_infohash: ' + resultData.bittorrent_infohash );
-		}
-		if ( resultData.bittorrent_trackers && resultData.bittorrent_trackers.length ) {
-			lines.push( 'bittorrent_trackers:' );
-			resultData.bittorrent_trackers.forEach( function ( tracker ) {
-				lines.push( '  - ' + tracker );
-			} );
-		}
 
 		var releaseYaml = lines.join( '\n' ) + '\n';
 

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -485,6 +485,9 @@
 		if ( /tag/.test( lower ) || /vorbis/.test( lower ) || /metadata/.test( lower ) ) {
 			return 'tagging';
 		}
+		if ( /torrent|infohash|magnet/.test( lower ) ) {
+			return 'torrenting';
+		}
 		if ( /pin/.test( lower ) || /upload/.test( lower ) || /ipfs/.test( lower ) ) {
 			return 'pinning';
 		}
@@ -592,6 +595,17 @@
 
 		lines.push( 'pinned_on:' );
 		lines.push( '  - delivery-kid' );
+
+		// BitTorrent fields from finalize result
+		if ( resultData.bittorrent_infohash ) {
+			lines.push( 'bittorrent_infohash: ' + resultData.bittorrent_infohash );
+		}
+		if ( resultData.bittorrent_trackers && resultData.bittorrent_trackers.length ) {
+			lines.push( 'bittorrent_trackers:' );
+			resultData.bittorrent_trackers.forEach( function ( tracker ) {
+				lines.push( '  - ' + tracker );
+			} );
+		}
 
 		var releaseYaml = lines.join( '\n' ) + '\n';
 

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -287,19 +287,25 @@
 			var data = collectFormData();
 			var draftId = data.draft_id;
 			if ( !draftId ) {
-				setStatus( 'No draft ID — cannot finalize.', 'error' );
+				showFinalizeError( 'No draft ID — cannot finalize.' );
 				return;
 			}
 
 			var album = data.album || {};
 			if ( !album.title ) {
-				setStatus( 'Album title is required to finalize.', 'error' );
+				showFinalizeError( 'Album title is required to finalize.' );
 				el( 'rd-album-title' ).focus();
 				return;
 			}
 			if ( !album.artist ) {
-				setStatus( 'Artist is required to finalize.', 'error' );
+				showFinalizeError( 'Artist is required to finalize.' );
 				el( 'rd-artist' ).focus();
+				return;
+			}
+
+			var apiUrl = mw.config.get( 'wgDeliveryKidUrl' );
+			if ( !apiUrl ) {
+				showFinalizeError( 'Delivery Kid is not configured. An admin needs to set DeliveryKidApiKey in LocalSettings.php.' );
 				return;
 			}
 
@@ -326,7 +332,6 @@
 				};
 			} );
 
-			var apiUrl = mw.config.get( 'wgDeliveryKidUrl' );
 			var authHeaders = {
 				'X-Upload-Token': mw.config.get( 'wgUploadToken' ),
 				'X-Upload-User': mw.config.get( 'wgUploadUser' ),
@@ -365,11 +370,20 @@
 				}
 				return readSSEStream( resp );
 			} ).catch( function ( err ) {
-				setStatus( 'Finalization error: ' + err.message, 'error' );
+				showFinalizeError( 'Finalization error: ' + err.message );
 				finalizeBtn.disabled = false;
 				el( 'rd-save-btn' ).disabled = false;
 			} );
 		} );
+	}
+
+	function showFinalizeError( msg ) {
+		// Always make the progress area visible so the error is seen
+		var progressDiv = el( 'rd-finalize-progress' );
+		if ( progressDiv ) {
+			progressDiv.style.display = '';
+		}
+		setStatus( msg, 'error' );
 	}
 
 	function readSSEStream( resp ) {
@@ -424,7 +438,7 @@
 			setStatus( 'Album pinned to IPFS!', 'success' );
 			saveResultToPage( data );
 		} else if ( event === 'error' ) {
-			setStatus( 'Error: ' + ( data.message || 'Unknown error' ), 'error' );
+			showFinalizeError( 'Error: ' + ( data.message || 'Unknown error' ) );
 			var finalizeBtn = el( 'rd-finalize-btn' );
 			var saveBtn = el( 'rd-save-btn' );
 			if ( finalizeBtn ) {

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.upload.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.upload.css
@@ -1,0 +1,189 @@
+/**
+ * Styles for Special:UploadContent
+ */
+
+.uc-step {
+	display: none;
+	margin: 1.5em 0;
+	padding: 1em;
+	border: 1px solid #a2a9b1;
+	border-radius: 4px;
+	background: #f8f9fa;
+}
+
+.uc-step-active {
+	display: block;
+}
+
+.uc-step h3 {
+	margin-top: 0;
+	border-bottom: 1px solid #a2a9b1;
+	padding-bottom: 0.5em;
+}
+
+/* Status messages */
+.uc-status {
+	margin: 0.75em 0;
+	padding: 0.5em;
+	font-size: 0.95em;
+}
+
+.uc-status:empty {
+	display: none;
+}
+
+.uc-status-success {
+	color: #14866d;
+	background: #d5fdf4;
+	border: 1px solid #14866d;
+	border-radius: 3px;
+	padding: 0.5em 0.75em;
+}
+
+.uc-status-error {
+	color: #d33;
+	background: #fee7e6;
+	border: 1px solid #d33;
+	border-radius: 3px;
+	padding: 0.5em 0.75em;
+}
+
+/* Dropzone */
+.uc-dropzone {
+	border: 2px dashed #a2a9b1;
+	border-radius: 6px;
+	padding: 2em;
+	text-align: center;
+	cursor: pointer;
+	transition: border-color 0.2s, background 0.2s;
+	margin-bottom: 1em;
+}
+
+.uc-dropzone:hover,
+.uc-dropzone-active {
+	border-color: #36c;
+	background: #eaf3ff;
+}
+
+.uc-hint {
+	font-size: 0.85em;
+	color: #72777d;
+}
+
+/* File list */
+.uc-file-list {
+	margin-bottom: 1em;
+}
+
+.uc-file-item {
+	display: flex;
+	align-items: center;
+	padding: 0.4em 0.6em;
+	margin: 0.25em 0;
+	background: #fff;
+	border: 1px solid #c8ccd1;
+	border-radius: 3px;
+}
+
+.uc-file-name {
+	flex: 1;
+	font-family: monospace;
+	font-size: 0.9em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.uc-file-size {
+	margin: 0 0.75em;
+	color: #72777d;
+	font-size: 0.85em;
+}
+
+.uc-file-remove {
+	background: none;
+	border: none;
+	color: #d33;
+	cursor: pointer;
+	font-size: 1.2em;
+	padding: 0 0.3em;
+}
+
+/* Metadata form */
+.uc-metadata-form {
+	margin: 1em 0;
+}
+
+.uc-field {
+	margin-bottom: 0.75em;
+}
+
+.uc-field label {
+	display: block;
+	font-weight: bold;
+	margin-bottom: 0.25em;
+}
+
+.uc-field input[type="text"],
+.uc-field textarea {
+	width: 100%;
+	max-width: 500px;
+	box-sizing: border-box;
+}
+
+.uc-checkbox-field label {
+	display: inline;
+	font-weight: normal;
+}
+
+.uc-draft-expires {
+	font-size: 0.85em;
+	color: #72777d;
+}
+
+/* Progress bar */
+.uc-progress-bar {
+	height: 20px;
+	background: #c8ccd1;
+	border-radius: 10px;
+	overflow: hidden;
+	margin: 1em 0;
+}
+
+.uc-progress-fill {
+	height: 100%;
+	background: #36c;
+	transition: width 0.3s ease;
+	width: 0%;
+}
+
+/* Result card */
+.uc-result-card {
+	margin-top: 1em;
+	padding: 1em;
+	background: #fff;
+	border: 1px solid #a2a9b1;
+	border-radius: 4px;
+}
+
+.uc-result-card h4 {
+	margin-top: 0;
+	color: #14866d;
+}
+
+.uc-result-card .release-cid-cell {
+	font-family: monospace;
+	word-break: break-all;
+	font-size: 0.9em;
+}
+
+/* Button spacing */
+.uc-step button + button {
+	margin-left: 0.5em;
+}
+
+/* Draft info table */
+.uc-draft-info .wikitable {
+	width: 100%;
+	max-width: 700px;
+}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.upload.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.upload.css
@@ -187,3 +187,62 @@
 	width: 100%;
 	max-width: 700px;
 }
+
+/* Button row */
+.uc-button-row {
+	margin-top: 1em;
+}
+
+/* Album track list */
+.ua-track-list {
+	margin: 0.5em 0 1em;
+}
+
+.ua-track-row {
+	display: flex;
+	align-items: center;
+	padding: 0.5em 0.6em;
+	margin: 0.25em 0;
+	background: #fff;
+	border: 1px solid #c8ccd1;
+	border-radius: 3px;
+	cursor: grab;
+	gap: 0.5em;
+}
+
+.ua-track-row.ua-track-dragging {
+	opacity: 0.4;
+}
+
+.ua-track-handle {
+	color: #72777d;
+	cursor: grab;
+	font-size: 1.1em;
+	user-select: none;
+}
+
+.ua-track-num {
+	font-weight: bold;
+	min-width: 1.5em;
+	text-align: center;
+	color: #54595d;
+}
+
+.ua-track-title {
+	flex: 1;
+	min-width: 0;
+}
+
+.ua-track-meta {
+	font-size: 0.8em;
+	color: #72777d;
+	white-space: nowrap;
+}
+
+.uc-status-warning {
+	color: #ac6600;
+	background: #fef6e7;
+	border: 1px solid #ac6600;
+	border-radius: 3px;
+	padding: 0.5em 0.75em;
+}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.upload.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.upload.js
@@ -1,0 +1,454 @@
+/**
+ * Upload Content — client-side workflow for Special:UploadContent.
+ *
+ * Steps: Connect Wallet → Upload Files → Review Metadata → Finalize (Pin to IPFS)
+ */
+( function () {
+	'use strict';
+
+	var DELIVERY_KID_URL = mw.config.get( 'wgDeliveryKidUrl' );
+	var currentDraftId = null;
+	var currentDraftFiles = null;
+	var walletAddress = null;
+
+	// -- Helpers --
+
+	function $( id ) {
+		return document.getElementById( id );
+	}
+
+	function setStatus( elementId, message, type ) {
+		var el = $( elementId );
+		el.textContent = message;
+		el.className = 'uc-status' + ( type ? ' uc-status-' + type : '' );
+	}
+
+	function showStep( stepId ) {
+		document.querySelectorAll( '.uc-step' ).forEach( function ( el ) {
+			el.classList.remove( 'uc-step-active' );
+		} );
+		$( stepId ).classList.add( 'uc-step-active' );
+	}
+
+	/**
+	 * Sign a message with the connected wallet and return auth headers.
+	 */
+	async function getAuthHeaders() {
+		var timestamp = Date.now();
+		var message = 'Authorize Blue Railroad pinning\nTimestamp: ' + timestamp;
+
+		try {
+			var signature = await window.ethereum.request( {
+				method: 'personal_sign',
+				params: [ message, walletAddress ]
+			} );
+			return {
+				'X-Signature': signature,
+				'X-Timestamp': timestamp.toString()
+			};
+		} catch ( err ) {
+			throw new Error( 'Wallet signature rejected: ' + err.message );
+		}
+	}
+
+	/**
+	 * Format bytes to human-readable size.
+	 */
+	function formatSize( bytes ) {
+		var units = [ 'B', 'KB', 'MB', 'GB' ];
+		var size = bytes;
+		var i = 0;
+		while ( size >= 1024 && i < units.length - 1 ) {
+			size /= 1024;
+			i++;
+		}
+		return size.toFixed( 1 ) + ' ' + units[ i ];
+	}
+
+	/**
+	 * Format duration in seconds to mm:ss.
+	 */
+	function formatDuration( seconds ) {
+		if ( !seconds ) {
+			return '';
+		}
+		var m = Math.floor( seconds / 60 );
+		var s = Math.floor( seconds % 60 );
+		return m + ':' + ( s < 10 ? '0' : '' ) + s;
+	}
+
+	// -- Step 1: Wallet Connection --
+
+	function initWalletStep() {
+		var connectBtn = $( 'uc-connect-wallet' );
+
+		connectBtn.addEventListener( 'click', async function () {
+			if ( !window.ethereum ) {
+				setStatus( 'uc-wallet-status', 'No Ethereum wallet detected. Please install MetaMask.', 'error' );
+				return;
+			}
+
+			try {
+				connectBtn.disabled = true;
+				setStatus( 'uc-wallet-status', 'Requesting wallet connection...', '' );
+
+				var accounts = await window.ethereum.request( {
+					method: 'eth_requestAccounts'
+				} );
+
+				if ( accounts.length === 0 ) {
+					setStatus( 'uc-wallet-status', 'No accounts available.', 'error' );
+					connectBtn.disabled = false;
+					return;
+				}
+
+				walletAddress = accounts[ 0 ];
+				setStatus( 'uc-wallet-status',
+					'Connected: ' + walletAddress.slice( 0, 6 ) + '...' + walletAddress.slice( -4 ),
+					'success'
+				);
+				connectBtn.textContent = 'Connected';
+
+				// Advance to upload step
+				showStep( 'uc-step-upload' );
+
+			} catch ( err ) {
+				setStatus( 'uc-wallet-status', 'Connection failed: ' + err.message, 'error' );
+				connectBtn.disabled = false;
+			}
+		} );
+	}
+
+	// -- Step 2: File Upload --
+
+	function initUploadStep() {
+		var dropzone = $( 'uc-dropzone' );
+		var fileInput = $( 'uc-file-input' );
+		var fileList = $( 'uc-file-list' );
+		var uploadBtn = $( 'uc-upload-btn' );
+		var selectedFiles = [];
+
+		dropzone.addEventListener( 'click', function () {
+			fileInput.click();
+		} );
+
+		dropzone.addEventListener( 'dragover', function ( e ) {
+			e.preventDefault();
+			dropzone.classList.add( 'uc-dropzone-active' );
+		} );
+
+		dropzone.addEventListener( 'dragleave', function () {
+			dropzone.classList.remove( 'uc-dropzone-active' );
+		} );
+
+		dropzone.addEventListener( 'drop', function ( e ) {
+			e.preventDefault();
+			dropzone.classList.remove( 'uc-dropzone-active' );
+			addFiles( e.dataTransfer.files );
+		} );
+
+		fileInput.addEventListener( 'change', function () {
+			addFiles( fileInput.files );
+			fileInput.value = '';
+		} );
+
+		function addFiles( newFiles ) {
+			for ( var i = 0; i < newFiles.length; i++ ) {
+				selectedFiles.push( newFiles[ i ] );
+			}
+			renderFileList();
+		}
+
+		function renderFileList() {
+			fileList.innerHTML = '';
+			selectedFiles.forEach( function ( file, idx ) {
+				var item = document.createElement( 'div' );
+				item.className = 'uc-file-item';
+				item.innerHTML =
+					'<span class="uc-file-name">' + mw.html.escape( file.name ) + '</span>' +
+					'<span class="uc-file-size">' + formatSize( file.size ) + '</span>' +
+					'<button class="uc-file-remove" data-idx="' + idx + '">&times;</button>';
+				fileList.appendChild( item );
+			} );
+
+			// Bind remove buttons
+			fileList.querySelectorAll( '.uc-file-remove' ).forEach( function ( btn ) {
+				btn.addEventListener( 'click', function () {
+					selectedFiles.splice( parseInt( btn.dataset.idx ), 1 );
+					renderFileList();
+				} );
+			} );
+
+			uploadBtn.disabled = selectedFiles.length === 0;
+		}
+
+		uploadBtn.addEventListener( 'click', async function () {
+			if ( selectedFiles.length === 0 ) {
+				return;
+			}
+
+			try {
+				uploadBtn.disabled = true;
+				setStatus( 'uc-upload-status', 'Signing authorization...', '' );
+
+				var headers = await getAuthHeaders();
+
+				setStatus( 'uc-upload-status', 'Uploading ' + selectedFiles.length + ' file(s)...', '' );
+
+				var formData = new FormData();
+				selectedFiles.forEach( function ( file ) {
+					formData.append( 'files', file );
+				} );
+
+				var resp = await fetch( DELIVERY_KID_URL + '/draft-content', {
+					method: 'POST',
+					headers: headers,
+					body: formData
+				} );
+
+				if ( !resp.ok ) {
+					var err = await resp.json().catch( function () {
+						return { detail: resp.statusText };
+					} );
+					throw new Error( err.detail || 'Upload failed' );
+				}
+
+				var draft = await resp.json();
+				currentDraftId = draft.draft_id;
+				currentDraftFiles = draft.files;
+
+				setStatus( 'uc-upload-status', 'Draft created: ' + currentDraftId.slice( 0, 8 ) + '...', 'success' );
+
+				// Advance to review
+				renderReviewStep( draft );
+				showStep( 'uc-step-review' );
+
+			} catch ( err ) {
+				setStatus( 'uc-upload-status', 'Upload failed: ' + err.message, 'error' );
+				uploadBtn.disabled = false;
+			}
+		} );
+	}
+
+	// -- Step 3: Review & Metadata --
+
+	function renderReviewStep( draft ) {
+		var info = $( 'uc-draft-info' );
+		var html = '<table class="wikitable">';
+		html += '<tr><th>File</th><th>Type</th><th>Format</th><th>Duration</th><th>Size</th></tr>';
+
+		draft.files.forEach( function ( f ) {
+			html += '<tr>';
+			html += '<td>' + mw.html.escape( f.original_filename ) + '</td>';
+			html += '<td>' + mw.html.escape( f.media_type ) + '</td>';
+			html += '<td>' + mw.html.escape( f.format ) + '</td>';
+			html += '<td>' + formatDuration( f.duration_seconds ) + '</td>';
+			html += '<td>' + formatSize( f.size_bytes ) + '</td>';
+			html += '</tr>';
+
+			// Show extra details for video/audio
+			if ( f.width && f.height ) {
+				html += '<tr><td></td><td colspan="4">' + f.width + 'x' + f.height;
+				if ( f.video_codec ) {
+					html += ' &middot; ' + mw.html.escape( f.video_codec );
+				}
+				if ( f.audio_codec ) {
+					html += ' &middot; ' + mw.html.escape( f.audio_codec );
+				}
+				html += '</td></tr>';
+			}
+		} );
+
+		html += '</table>';
+		html += '<p class="uc-draft-expires">Draft expires: ' +
+			new Date( draft.expires_at ).toLocaleString() + '</p>';
+
+		info.innerHTML = html;
+
+		// Pre-fill title from first file if only one
+		if ( draft.files.length === 1 && draft.files[ 0 ].detected_title ) {
+			$( 'uc-title' ).value = draft.files[ 0 ].detected_title;
+		}
+
+		// Show HLS option only if there's a video file
+		var hasVideo = draft.files.some( function ( f ) {
+			return f.media_type === 'video';
+		} );
+		$( 'uc-transcode-hls' ).parentElement.parentElement.style.display = hasVideo ? '' : 'none';
+	}
+
+	function initReviewStep() {
+		$( 'uc-finalize-btn' ).addEventListener( 'click', async function () {
+			await startFinalization();
+		} );
+
+		$( 'uc-delete-draft-btn' ).addEventListener( 'click', async function () {
+			if ( !currentDraftId ) {
+				return;
+			}
+			if ( !confirm( 'Delete this draft? This cannot be undone.' ) ) {
+				return;
+			}
+
+			try {
+				var headers = await getAuthHeaders();
+				await fetch( DELIVERY_KID_URL + '/draft-content/' + currentDraftId, {
+					method: 'DELETE',
+					headers: headers
+				} );
+				currentDraftId = null;
+				currentDraftFiles = null;
+				showStep( 'uc-step-upload' );
+				setStatus( 'uc-upload-status', 'Draft deleted.', '' );
+			} catch ( err ) {
+				setStatus( 'uc-progress-status', 'Delete failed: ' + err.message, 'error' );
+			}
+		} );
+	}
+
+	// -- Step 4: Finalization --
+
+	async function startFinalization() {
+		if ( !currentDraftId ) {
+			return;
+		}
+
+		showStep( 'uc-step-progress' );
+		setProgress( 0 );
+		setStatus( 'uc-progress-status', 'Starting finalization...', '' );
+
+		try {
+			var headers = await getAuthHeaders();
+			headers[ 'Content-Type' ] = 'application/json';
+
+			var body = {
+				title: $( 'uc-title' ).value || null,
+				description: $( 'uc-description' ).value || null,
+				file_type: $( 'uc-file-type' ).value || null,
+				subsequent_to: $( 'uc-subsequent-to' ).value || null,
+				transcode_hls: $( 'uc-transcode-hls' ).checked,
+				metadata: {}
+			};
+
+			var resp = await fetch(
+				DELIVERY_KID_URL + '/draft-content/' + currentDraftId + '/finalize',
+				{
+					method: 'POST',
+					headers: headers,
+					body: JSON.stringify( body )
+				}
+			);
+
+			if ( !resp.ok ) {
+				var err = await resp.json().catch( function () {
+					return { detail: resp.statusText };
+				} );
+				throw new Error( err.detail || 'Finalization failed' );
+			}
+
+			// Read SSE stream
+			var reader = resp.body.getReader();
+			var decoder = new TextDecoder();
+			var buffer = '';
+
+			while ( true ) {
+				var result = await reader.read();
+				if ( result.done ) {
+					break;
+				}
+
+				buffer += decoder.decode( result.value, { stream: true } );
+				var lines = buffer.split( '\n' );
+				buffer = lines.pop(); // Keep incomplete line in buffer
+
+				var currentEvent = '';
+				for ( var i = 0; i < lines.length; i++ ) {
+					var line = lines[ i ].trim();
+					if ( line.startsWith( 'event:' ) ) {
+						currentEvent = line.slice( 6 ).trim();
+					} else if ( line.startsWith( 'data:' ) ) {
+						var data = line.slice( 5 ).trim();
+						try {
+							handleSSEEvent( currentEvent, JSON.parse( data ) );
+						} catch ( e ) {
+							// Skip malformed data
+						}
+					}
+				}
+			}
+		} catch ( err ) {
+			setStatus( 'uc-progress-status', 'Error: ' + err.message, 'error' );
+		}
+	}
+
+	function handleSSEEvent( event, data ) {
+		if ( event === 'progress' ) {
+			setProgress( data.progress || 0 );
+			setStatus( 'uc-progress-status', data.message || '', '' );
+
+		} else if ( event === 'complete' ) {
+			setProgress( 100 );
+			setStatus( 'uc-progress-status', 'Pinning complete!', 'success' );
+			renderResult( data );
+			currentDraftId = null;
+
+		} else if ( event === 'error' ) {
+			setStatus( 'uc-progress-status', 'Error: ' + ( data.message || 'Unknown error' ), 'error' );
+		}
+	}
+
+	function setProgress( pct ) {
+		var fill = document.querySelector( '#uc-progress-bar .uc-progress-fill' );
+		if ( fill ) {
+			fill.style.width = pct + '%';
+		}
+	}
+
+	function renderResult( data ) {
+		var resultEl = $( 'uc-result' );
+		var releaseUrl = mw.util.getUrl( 'Release:' + data.cid );
+
+		var html = '<div class="uc-result-card">';
+		html += '<h4>Content Pinned Successfully</h4>';
+		html += '<table class="wikitable">';
+		if ( data.title ) {
+			html += '<tr><th>Title</th><td>' + mw.html.escape( data.title ) + '</td></tr>';
+		}
+		html += '<tr><th>CID</th><td class="release-cid-cell">' + mw.html.escape( data.cid ) + '</td></tr>';
+		html += '<tr><th>Gateway</th><td><a href="' + mw.html.escape( data.gateway_url ) +
+			'" target="_blank">' + mw.html.escape( data.gateway_url ) + '</a></td></tr>';
+		html += '<tr><th>Pinata</th><td>' + ( data.pinata ? 'Yes' : 'No' ) + '</td></tr>';
+		if ( data.subsequent_to ) {
+			html += '<tr><th>Supersedes</th><td>' + mw.html.escape( data.subsequent_to ) + '</td></tr>';
+		}
+		html += '</table>';
+		html += '<p><a href="' + mw.html.escape( releaseUrl ) +
+			'" class="cdx-button cdx-button--action-progressive">View Release Page</a></p>';
+		html += '<button id="uc-start-over" class="cdx-button">Upload More Content</button>';
+		html += '</div>';
+
+		resultEl.innerHTML = html;
+
+		$( 'uc-start-over' ).addEventListener( 'click', function () {
+			resultEl.innerHTML = '';
+			showStep( 'uc-step-upload' );
+		} );
+	}
+
+	// -- Init --
+
+	function init() {
+		if ( !DELIVERY_KID_URL ) {
+			document.querySelector( '.uc-step' ).innerHTML =
+				'<p class="uc-status uc-status-error">Delivery Kid URL not configured. Set $wgDeliveryKidUrl in LocalSettings.php.</p>';
+			return;
+		}
+
+		initWalletStep();
+		initUploadStep();
+		initReviewStep();
+	}
+
+	mw.loader.using( 'mediawiki.util' ).then( init );
+
+}() );

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.upload.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.upload.js
@@ -161,14 +161,24 @@
 			progressBar.style.display = 'none';
 
 			if ( xhr.status !== 200 ) {
-				var err;
+				var errMsg;
 				try {
-					err = JSON.parse( xhr.responseText );
+					var err = JSON.parse( xhr.responseText );
+					var detail = err.detail;
+					if ( typeof detail === 'string' ) {
+						errMsg = detail;
+					} else if ( detail && detail.error ) {
+						errMsg = detail.error;
+					} else if ( Array.isArray( detail ) ) {
+						errMsg = detail.map( function ( d ) { return d.msg || JSON.stringify( d ); } ).join( '; ' );
+					} else {
+						errMsg = JSON.stringify( err );
+					}
 				} catch ( e ) {
-					err = { detail: xhr.statusText };
+					errMsg = xhr.status + ' ' + xhr.statusText + ': ' + xhr.responseText.slice( 0, 200 );
 				}
 				setStatus( 'uc-upload-status',
-					'Upload failed: ' + ( err.detail || xhr.statusText ), 'error' );
+					'Upload failed (' + xhr.status + '): ' + errMsg, 'error' );
 				uploadBtn.disabled = false;
 				return;
 			}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.upload.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.upload.js
@@ -1,59 +1,40 @@
 /**
- * Upload Content — client-side workflow for Special:UploadContent.
+ * Upload Content — direct upload to delivery-kid from browser.
  *
- * Steps: Connect Wallet → Upload Files → Review Metadata → Finalize (Pin to IPFS)
+ * Wiki generates an HMAC token. JS uploads directly to delivery-kid.
+ * No bytes pass through PHP.
  */
 ( function () {
 	'use strict';
 
-	var DELIVERY_KID_URL = mw.config.get( 'wgDeliveryKidUrl' );
+	var API_URL = mw.config.get( 'wgDeliveryKidUrl' );
+	var AUTH_HEADERS = {
+		'X-Upload-Token': mw.config.get( 'wgUploadToken' ),
+		'X-Upload-User': mw.config.get( 'wgUploadUser' ),
+		'X-Upload-Timestamp': String( mw.config.get( 'wgUploadTimestamp' ) )
+	};
+
 	var currentDraftId = null;
-	var currentDraftFiles = null;
-	var walletAddress = null;
 
 	// -- Helpers --
 
-	function $( id ) {
+	function el( id ) {
 		return document.getElementById( id );
 	}
 
 	function setStatus( elementId, message, type ) {
-		var el = $( elementId );
-		el.textContent = message;
-		el.className = 'uc-status' + ( type ? ' uc-status-' + type : '' );
+		var e = el( elementId );
+		e.textContent = message;
+		e.className = 'uc-status' + ( type ? ' uc-status-' + type : '' );
 	}
 
 	function showStep( stepId ) {
-		document.querySelectorAll( '.uc-step' ).forEach( function ( el ) {
-			el.classList.remove( 'uc-step-active' );
+		document.querySelectorAll( '.uc-step' ).forEach( function ( s ) {
+			s.classList.remove( 'uc-step-active' );
 		} );
-		$( stepId ).classList.add( 'uc-step-active' );
+		el( stepId ).classList.add( 'uc-step-active' );
 	}
 
-	/**
-	 * Sign a message with the connected wallet and return auth headers.
-	 */
-	async function getAuthHeaders() {
-		var timestamp = Date.now();
-		var message = 'Authorize Blue Railroad pinning\nTimestamp: ' + timestamp;
-
-		try {
-			var signature = await window.ethereum.request( {
-				method: 'personal_sign',
-				params: [ message, walletAddress ]
-			} );
-			return {
-				'X-Signature': signature,
-				'X-Timestamp': timestamp.toString()
-			};
-		} catch ( err ) {
-			throw new Error( 'Wallet signature rejected: ' + err.message );
-		}
-	}
-
-	/**
-	 * Format bytes to human-readable size.
-	 */
 	function formatSize( bytes ) {
 		var units = [ 'B', 'KB', 'MB', 'GB' ];
 		var size = bytes;
@@ -65,9 +46,6 @@
 		return size.toFixed( 1 ) + ' ' + units[ i ];
 	}
 
-	/**
-	 * Format duration in seconds to mm:ss.
-	 */
 	function formatDuration( seconds ) {
 		if ( !seconds ) {
 			return '';
@@ -77,55 +55,13 @@
 		return m + ':' + ( s < 10 ? '0' : '' ) + s;
 	}
 
-	// -- Step 1: Wallet Connection --
-
-	function initWalletStep() {
-		var connectBtn = $( 'uc-connect-wallet' );
-
-		connectBtn.addEventListener( 'click', async function () {
-			if ( !window.ethereum ) {
-				setStatus( 'uc-wallet-status', 'No Ethereum wallet detected. Please install MetaMask.', 'error' );
-				return;
-			}
-
-			try {
-				connectBtn.disabled = true;
-				setStatus( 'uc-wallet-status', 'Requesting wallet connection...', '' );
-
-				var accounts = await window.ethereum.request( {
-					method: 'eth_requestAccounts'
-				} );
-
-				if ( accounts.length === 0 ) {
-					setStatus( 'uc-wallet-status', 'No accounts available.', 'error' );
-					connectBtn.disabled = false;
-					return;
-				}
-
-				walletAddress = accounts[ 0 ];
-				setStatus( 'uc-wallet-status',
-					'Connected: ' + walletAddress.slice( 0, 6 ) + '...' + walletAddress.slice( -4 ),
-					'success'
-				);
-				connectBtn.textContent = 'Connected';
-
-				// Advance to upload step
-				showStep( 'uc-step-upload' );
-
-			} catch ( err ) {
-				setStatus( 'uc-wallet-status', 'Connection failed: ' + err.message, 'error' );
-				connectBtn.disabled = false;
-			}
-		} );
-	}
-
-	// -- Step 2: File Upload --
+	// -- Step 1: File Upload --
 
 	function initUploadStep() {
-		var dropzone = $( 'uc-dropzone' );
-		var fileInput = $( 'uc-file-input' );
-		var fileList = $( 'uc-file-list' );
-		var uploadBtn = $( 'uc-upload-btn' );
+		var dropzone = el( 'uc-dropzone' );
+		var fileInput = el( 'uc-file-input' );
+		var fileList = el( 'uc-file-list' );
+		var uploadBtn = el( 'uc-upload-btn' );
 		var selectedFiles = [];
 
 		dropzone.addEventListener( 'click', function () {
@@ -171,7 +107,6 @@
 				fileList.appendChild( item );
 			} );
 
-			// Bind remove buttons
 			fileList.querySelectorAll( '.uc-file-remove' ).forEach( function ( btn ) {
 				btn.addEventListener( 'click', function () {
 					selectedFiles.splice( parseInt( btn.dataset.idx ), 1 );
@@ -182,61 +117,89 @@
 			uploadBtn.disabled = selectedFiles.length === 0;
 		}
 
-		uploadBtn.addEventListener( 'click', async function () {
+		uploadBtn.addEventListener( 'click', function () {
 			if ( selectedFiles.length === 0 ) {
 				return;
 			}
-
-			try {
-				uploadBtn.disabled = true;
-				setStatus( 'uc-upload-status', 'Signing authorization...', '' );
-
-				var headers = await getAuthHeaders();
-
-				setStatus( 'uc-upload-status', 'Uploading ' + selectedFiles.length + ' file(s)...', '' );
-
-				var formData = new FormData();
-				selectedFiles.forEach( function ( file ) {
-					formData.append( 'files', file );
-				} );
-
-				var resp = await fetch( DELIVERY_KID_URL + '/draft-content', {
-					method: 'POST',
-					headers: headers,
-					body: formData
-				} );
-
-				if ( !resp.ok ) {
-					var err = await resp.json().catch( function () {
-						return { detail: resp.statusText };
-					} );
-					throw new Error( err.detail || 'Upload failed' );
-				}
-
-				var draft = await resp.json();
-				currentDraftId = draft.draft_id;
-				currentDraftFiles = draft.files;
-
-				setStatus( 'uc-upload-status', 'Draft created: ' + currentDraftId.slice( 0, 8 ) + '...', 'success' );
-
-				// Advance to review
-				renderReviewStep( draft );
-				showStep( 'uc-step-review' );
-
-			} catch ( err ) {
-				setStatus( 'uc-upload-status', 'Upload failed: ' + err.message, 'error' );
-				uploadBtn.disabled = false;
-			}
+			doUpload( selectedFiles );
 		} );
 	}
 
-	// -- Step 3: Review & Metadata --
+	function doUpload( files ) {
+		var uploadBtn = el( 'uc-upload-btn' );
+		var progressBar = el( 'uc-upload-progress' );
+		var progressFill = progressBar.querySelector( '.uc-progress-fill' );
 
-	function renderReviewStep( draft ) {
-		var info = $( 'uc-draft-info' );
+		uploadBtn.disabled = true;
+		progressBar.style.display = '';
+		setStatus( 'uc-upload-status', 'Uploading ' + files.length + ' file(s)...', '' );
+
+		var formData = new FormData();
+		files.forEach( function ( file ) {
+			formData.append( 'files', file );
+		} );
+
+		var xhr = new XMLHttpRequest();
+		xhr.open( 'POST', API_URL + '/draft-content' );
+
+		// Set auth headers
+		Object.keys( AUTH_HEADERS ).forEach( function ( key ) {
+			xhr.setRequestHeader( key, AUTH_HEADERS[ key ] );
+		} );
+
+		xhr.upload.addEventListener( 'progress', function ( e ) {
+			if ( e.lengthComputable ) {
+				var pct = Math.round( ( e.loaded / e.total ) * 100 );
+				progressFill.style.width = pct + '%';
+				setStatus( 'uc-upload-status',
+					'Uploading... ' + formatSize( e.loaded ) + ' / ' + formatSize( e.total ) +
+					' (' + pct + '%)', '' );
+			}
+		} );
+
+		xhr.addEventListener( 'load', function () {
+			progressBar.style.display = 'none';
+
+			if ( xhr.status !== 200 ) {
+				var err;
+				try {
+					err = JSON.parse( xhr.responseText );
+				} catch ( e ) {
+					err = { detail: xhr.statusText };
+				}
+				setStatus( 'uc-upload-status',
+					'Upload failed: ' + ( err.detail || xhr.statusText ), 'error' );
+				uploadBtn.disabled = false;
+				return;
+			}
+
+			var draft = JSON.parse( xhr.responseText );
+			currentDraftId = draft.draft_id;
+
+			setStatus( 'uc-upload-status',
+				'Draft created: ' + currentDraftId.slice( 0, 8 ) + '...', 'success' );
+
+			renderReview( draft );
+			showStep( 'uc-step-review' );
+		} );
+
+		xhr.addEventListener( 'error', function () {
+			progressBar.style.display = 'none';
+			setStatus( 'uc-upload-status', 'Network error during upload.', 'error' );
+			uploadBtn.disabled = false;
+		} );
+
+		xhr.send( formData );
+	}
+
+	// -- Step 2: Review & Metadata --
+
+	function renderReview( draft ) {
+		var info = el( 'uc-draft-info' );
 		var html = '<table class="wikitable">';
 		html += '<tr><th>File</th><th>Type</th><th>Format</th><th>Duration</th><th>Size</th></tr>';
 
+		var hasVideo = false;
 		draft.files.forEach( function ( f ) {
 			html += '<tr>';
 			html += '<td>' + mw.html.escape( f.original_filename ) + '</td>';
@@ -246,7 +209,6 @@
 			html += '<td>' + formatSize( f.size_bytes ) + '</td>';
 			html += '</tr>';
 
-			// Show extra details for video/audio
 			if ( f.width && f.height ) {
 				html += '<tr><td></td><td colspan="4">' + f.width + 'x' + f.height;
 				if ( f.video_codec ) {
@@ -257,58 +219,48 @@
 				}
 				html += '</td></tr>';
 			}
+
+			if ( f.media_type === 'video' ) {
+				hasVideo = true;
+			}
 		} );
 
 		html += '</table>';
 		html += '<p class="uc-draft-expires">Draft expires: ' +
 			new Date( draft.expires_at ).toLocaleString() + '</p>';
-
 		info.innerHTML = html;
 
-		// Pre-fill title from first file if only one
+		// Pre-fill title
 		if ( draft.files.length === 1 && draft.files[ 0 ].detected_title ) {
-			$( 'uc-title' ).value = draft.files[ 0 ].detected_title;
+			el( 'uc-title' ).value = draft.files[ 0 ].detected_title;
 		}
 
-		// Show HLS option only if there's a video file
-		var hasVideo = draft.files.some( function ( f ) {
-			return f.media_type === 'video';
-		} );
-		$( 'uc-transcode-hls' ).parentElement.parentElement.style.display = hasVideo ? '' : 'none';
+		el( 'uc-hls-field' ).style.display = hasVideo ? '' : 'none';
 	}
 
 	function initReviewStep() {
-		$( 'uc-finalize-btn' ).addEventListener( 'click', async function () {
-			await startFinalization();
+		el( 'uc-finalize-btn' ).addEventListener( 'click', function () {
+			startFinalization();
 		} );
 
-		$( 'uc-delete-draft-btn' ).addEventListener( 'click', async function () {
-			if ( !currentDraftId ) {
+		el( 'uc-delete-draft-btn' ).addEventListener( 'click', function () {
+			if ( !currentDraftId || !confirm( 'Delete this draft? This cannot be undone.' ) ) {
 				return;
 			}
-			if ( !confirm( 'Delete this draft? This cannot be undone.' ) ) {
-				return;
-			}
-
-			try {
-				var headers = await getAuthHeaders();
-				await fetch( DELIVERY_KID_URL + '/draft-content/' + currentDraftId, {
-					method: 'DELETE',
-					headers: headers
-				} );
+			fetch( API_URL + '/draft-content/' + currentDraftId, {
+				method: 'DELETE',
+				headers: AUTH_HEADERS
+			} ).then( function () {
 				currentDraftId = null;
-				currentDraftFiles = null;
 				showStep( 'uc-step-upload' );
 				setStatus( 'uc-upload-status', 'Draft deleted.', '' );
-			} catch ( err ) {
-				setStatus( 'uc-progress-status', 'Delete failed: ' + err.message, 'error' );
-			}
+			} );
 		} );
 	}
 
-	// -- Step 4: Finalization --
+	// -- Step 3: Finalize --
 
-	async function startFinalization() {
+	function startFinalization() {
 		if ( !currentDraftId ) {
 			return;
 		}
@@ -317,83 +269,84 @@
 		setProgress( 0 );
 		setStatus( 'uc-progress-status', 'Starting finalization...', '' );
 
-		try {
-			var headers = await getAuthHeaders();
-			headers[ 'Content-Type' ] = 'application/json';
+		var headers = Object.assign( {}, AUTH_HEADERS, {
+			'Content-Type': 'application/json'
+		} );
 
-			var body = {
-				title: $( 'uc-title' ).value || null,
-				description: $( 'uc-description' ).value || null,
-				file_type: $( 'uc-file-type' ).value || null,
-				subsequent_to: $( 'uc-subsequent-to' ).value || null,
-				transcode_hls: $( 'uc-transcode-hls' ).checked,
-				metadata: {}
-			};
+		var body = JSON.stringify( {
+			title: el( 'uc-title' ).value || null,
+			description: el( 'uc-description' ).value || null,
+			file_type: el( 'uc-file-type' ).value || null,
+			subsequent_to: el( 'uc-subsequent-to' ).value || null,
+			transcode_hls: el( 'uc-transcode-hls' ).checked,
+			metadata: {}
+		} );
 
-			var resp = await fetch(
-				DELIVERY_KID_URL + '/draft-content/' + currentDraftId + '/finalize',
-				{
-					method: 'POST',
-					headers: headers,
-					body: JSON.stringify( body )
-				}
-			);
-
+		fetch( API_URL + '/draft-content/' + currentDraftId + '/finalize', {
+			method: 'POST',
+			headers: headers,
+			body: body
+		} ).then( function ( resp ) {
 			if ( !resp.ok ) {
-				var err = await resp.json().catch( function () {
-					return { detail: resp.statusText };
+				return resp.json().then( function ( err ) {
+					throw new Error( err.detail || resp.statusText );
 				} );
-				throw new Error( err.detail || 'Finalization failed' );
 			}
+			return readSSEStream( resp );
+		} ).catch( function ( err ) {
+			setStatus( 'uc-progress-status', 'Error: ' + err.message, 'error' );
+		} );
+	}
 
-			// Read SSE stream
-			var reader = resp.body.getReader();
-			var decoder = new TextDecoder();
-			var buffer = '';
+	function readSSEStream( resp ) {
+		var reader = resp.body.getReader();
+		var decoder = new TextDecoder();
+		var buffer = '';
 
-			while ( true ) {
-				var result = await reader.read();
+		function pump() {
+			return reader.read().then( function ( result ) {
 				if ( result.done ) {
-					break;
+					return;
 				}
 
 				buffer += decoder.decode( result.value, { stream: true } );
 				var lines = buffer.split( '\n' );
-				buffer = lines.pop(); // Keep incomplete line in buffer
+				buffer = lines.pop();
 
 				var currentEvent = '';
 				for ( var i = 0; i < lines.length; i++ ) {
 					var line = lines[ i ].trim();
-					if ( line.startsWith( 'event:' ) ) {
+					if ( line.indexOf( 'event:' ) === 0 ) {
 						currentEvent = line.slice( 6 ).trim();
-					} else if ( line.startsWith( 'data:' ) ) {
+					} else if ( line.indexOf( 'data:' ) === 0 ) {
 						var data = line.slice( 5 ).trim();
 						try {
 							handleSSEEvent( currentEvent, JSON.parse( data ) );
 						} catch ( e ) {
-							// Skip malformed data
+							// skip malformed
 						}
 					}
 				}
-			}
-		} catch ( err ) {
-			setStatus( 'uc-progress-status', 'Error: ' + err.message, 'error' );
+
+				return pump();
+			} );
 		}
+
+		return pump();
 	}
 
 	function handleSSEEvent( event, data ) {
 		if ( event === 'progress' ) {
 			setProgress( data.progress || 0 );
 			setStatus( 'uc-progress-status', data.message || '', '' );
-
 		} else if ( event === 'complete' ) {
 			setProgress( 100 );
 			setStatus( 'uc-progress-status', 'Pinning complete!', 'success' );
 			renderResult( data );
 			currentDraftId = null;
-
 		} else if ( event === 'error' ) {
-			setStatus( 'uc-progress-status', 'Error: ' + ( data.message || 'Unknown error' ), 'error' );
+			setStatus( 'uc-progress-status',
+				'Error: ' + ( data.message || 'Unknown error' ), 'error' );
 		}
 	}
 
@@ -405,7 +358,7 @@
 	}
 
 	function renderResult( data ) {
-		var resultEl = $( 'uc-result' );
+		var resultEl = el( 'uc-result' );
 		var releaseUrl = mw.util.getUrl( 'Release:' + data.cid );
 
 		var html = '<div class="uc-result-card">';
@@ -414,12 +367,16 @@
 		if ( data.title ) {
 			html += '<tr><th>Title</th><td>' + mw.html.escape( data.title ) + '</td></tr>';
 		}
-		html += '<tr><th>CID</th><td class="release-cid-cell">' + mw.html.escape( data.cid ) + '</td></tr>';
-		html += '<tr><th>Gateway</th><td><a href="' + mw.html.escape( data.gateway_url ) +
-			'" target="_blank">' + mw.html.escape( data.gateway_url ) + '</a></td></tr>';
+		html += '<tr><th>CID</th><td class="release-cid-cell">' +
+			mw.html.escape( data.cid ) + '</td></tr>';
+		if ( data.gateway_url ) {
+			html += '<tr><th>Gateway</th><td><a href="' + mw.html.escape( data.gateway_url ) +
+				'" target="_blank">' + mw.html.escape( data.gateway_url ) + '</a></td></tr>';
+		}
 		html += '<tr><th>Pinata</th><td>' + ( data.pinata ? 'Yes' : 'No' ) + '</td></tr>';
 		if ( data.subsequent_to ) {
-			html += '<tr><th>Supersedes</th><td>' + mw.html.escape( data.subsequent_to ) + '</td></tr>';
+			html += '<tr><th>Supersedes</th><td>' +
+				mw.html.escape( data.subsequent_to ) + '</td></tr>';
 		}
 		html += '</table>';
 		html += '<p><a href="' + mw.html.escape( releaseUrl ) +
@@ -429,7 +386,7 @@
 
 		resultEl.innerHTML = html;
 
-		$( 'uc-start-over' ).addEventListener( 'click', function () {
+		el( 'uc-start-over' ).addEventListener( 'click', function () {
 			resultEl.innerHTML = '';
 			showStep( 'uc-step-upload' );
 		} );
@@ -438,13 +395,12 @@
 	// -- Init --
 
 	function init() {
-		if ( !DELIVERY_KID_URL ) {
-			document.querySelector( '.uc-step' ).innerHTML =
-				'<p class="uc-status uc-status-error">Delivery Kid URL not configured. Set $wgDeliveryKidUrl in LocalSettings.php.</p>';
+		if ( !API_URL ) {
+			el( 'uc-step-upload' ).innerHTML =
+				'<p class="uc-status uc-status-error">Delivery Kid URL not configured.</p>';
 			return;
 		}
 
-		initWalletStep();
 		initUploadStep();
 		initReviewStep();
 	}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
@@ -19,6 +19,23 @@
 	var currentDraftId = null;
 	var draftFiles = []; // analyzed files from draft response
 
+	// -- URL draft persistence --
+
+	function getDraftIdFromUrl() {
+		var params = new URLSearchParams( window.location.search );
+		return params.get( 'draft' );
+	}
+
+	function setDraftIdInUrl( draftId ) {
+		var url = new URL( window.location.href );
+		if ( draftId ) {
+			url.searchParams.set( 'draft', draftId );
+		} else {
+			url.searchParams.delete( 'draft' );
+		}
+		history.replaceState( null, '', url.toString() );
+	}
+
 	// -- Helpers --
 
 	function el( id ) {
@@ -189,6 +206,7 @@
 			var draft = JSON.parse( xhr.responseText );
 			currentDraftId = draft.draft_id;
 			draftFiles = draft.files;
+			setDraftIdInUrl( currentDraftId );
 
 			setStatus( 'ua-upload-status',
 				'Draft created. ' + draftFiles.length + ' track(s) analyzed.', 'success' );
@@ -357,6 +375,7 @@
 			} ).then( function () {
 				currentDraftId = null;
 				draftFiles = [];
+				setDraftIdInUrl( null );
 				showStep( 'ua-step-upload' );
 				setStatus( 'ua-upload-status', 'Draft deleted.', '' );
 			} );
@@ -455,6 +474,7 @@
 			renderResult( data );
 			currentDraftId = null;
 			draftFiles = [];
+			setDraftIdInUrl( null );
 		} else if ( event === 'error' ) {
 			setStatus( 'ua-progress-status',
 				'Error: ' + ( data.message || 'Unknown error' ), 'error' );
@@ -507,6 +527,50 @@
 		} );
 	}
 
+	// -- Resume draft --
+
+	function resumeDraft( draftId ) {
+		setStatus( 'ua-upload-status', 'Resuming draft ' + draftId.slice( 0, 8 ) + '...', '' );
+
+		fetch( API_URL + '/draft-album/' + draftId, {
+			headers: AUTH_HEADERS
+		} ).then( function ( resp ) {
+			if ( resp.status === 410 ) {
+				setStatus( 'ua-upload-status', 'That draft has expired. Upload again.', 'error' );
+				setDraftIdInUrl( null );
+				return;
+			}
+			if ( resp.status === 404 ) {
+				setStatus( 'ua-upload-status', 'Draft not found. It may have been deleted or finalized.', 'error' );
+				setDraftIdInUrl( null );
+				return;
+			}
+			if ( !resp.ok ) {
+				return resp.json().then( function ( err ) {
+					var msg = ( err.detail && typeof err.detail === 'string' ) ? err.detail : JSON.stringify( err );
+					setStatus( 'ua-upload-status', 'Could not resume draft: ' + msg, 'error' );
+					setDraftIdInUrl( null );
+				} );
+			}
+			return resp.json();
+		} ).then( function ( draft ) {
+			if ( !draft ) {
+				return;
+			}
+			currentDraftId = draft.draft_id;
+			draftFiles = draft.files;
+
+			setStatus( 'ua-upload-status',
+				'Draft resumed. ' + draftFiles.length + ' track(s).', 'success' );
+
+			renderReview( draft );
+			showStep( 'ua-step-review' );
+		} ).catch( function ( err ) {
+			setStatus( 'ua-upload-status', 'Network error resuming draft: ' + err.message, 'error' );
+			setDraftIdInUrl( null );
+		} );
+	}
+
 	// -- Init --
 
 	function init() {
@@ -518,6 +582,12 @@
 
 		initUploadStep();
 		initReviewStep();
+
+		// Check for draft ID in URL (resume after page reload or shared link)
+		var urlDraftId = getDraftIdFromUrl();
+		if ( urlDraftId ) {
+			resumeDraft( urlDraftId );
+		}
 	}
 
 	mw.loader.using( 'mediawiki.util' ).then( init );

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
@@ -232,7 +232,7 @@
 		lines.push( 'album:' );
 		lines.push( '    title: ""' );
 		lines.push( '    artist: ""' );
-		lines.push( '    year: ""' );
+		lines.push( '    version: ""' );
 		lines.push( '    description: ""' );
 		lines.push( 'tracks:' );
 

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
@@ -1,10 +1,8 @@
 /**
  * Upload Album — direct upload to delivery-kid from browser.
  *
- * Three-step flow using /draft-album:
- * 1. Upload audio + cover → delivery-kid analyzes tracks
- * 2. Review: reorder tracks, edit titles, set album metadata
- * 3. Finalize → transcode FLAC/WAV→OGG, embed tags, pin to IPFS
+ * After upload+analysis, creates a ReleaseDraft wiki page and redirects there.
+ * The ReleaseDraft namespace handles review, metadata editing, and finalization.
  */
 ( function () {
 	'use strict';
@@ -15,26 +13,6 @@
 		'X-Upload-User': mw.config.get( 'wgUploadUser' ),
 		'X-Upload-Timestamp': String( mw.config.get( 'wgUploadTimestamp' ) )
 	};
-
-	var currentDraftId = null;
-	var draftFiles = []; // analyzed files from draft response
-
-	// -- URL draft persistence --
-
-	function getDraftIdFromUrl() {
-		var params = new URLSearchParams( window.location.search );
-		return params.get( 'draft' );
-	}
-
-	function setDraftIdInUrl( draftId ) {
-		var url = new URL( window.location.href );
-		if ( draftId ) {
-			url.searchParams.set( 'draft', draftId );
-		} else {
-			url.searchParams.delete( 'draft' );
-		}
-		history.replaceState( null, '', url.toString() );
-	}
 
 	// -- Helpers --
 
@@ -48,13 +26,6 @@
 		e.className = 'uc-status' + ( type ? ' uc-status-' + type : '' );
 	}
 
-	function showStep( stepId ) {
-		document.querySelectorAll( '.uc-step' ).forEach( function ( s ) {
-			s.classList.remove( 'uc-step-active' );
-		} );
-		el( stepId ).classList.add( 'uc-step-active' );
-	}
-
 	function formatSize( bytes ) {
 		var units = [ 'B', 'KB', 'MB', 'GB' ];
 		var size = bytes;
@@ -66,16 +37,7 @@
 		return size.toFixed( 1 ) + ' ' + units[ i ];
 	}
 
-	function formatDuration( seconds ) {
-		if ( !seconds ) {
-			return '';
-		}
-		var m = Math.floor( seconds / 60 );
-		var s = Math.floor( seconds % 60 );
-		return m + ':' + ( s < 10 ? '0' : '' ) + s;
-	}
-
-	// -- Step 1: File Upload --
+	// -- File Upload --
 
 	function initUploadStep() {
 		var dropzone = el( 'ua-dropzone' );
@@ -162,7 +124,6 @@
 		var xhr = new XMLHttpRequest();
 		xhr.open( 'POST', API_URL + '/draft-album' );
 
-		// Set auth headers
 		Object.keys( AUTH_HEADERS ).forEach( function ( key ) {
 			xhr.setRequestHeader( key, AUTH_HEADERS[ key ] );
 		} );
@@ -204,15 +165,10 @@
 			}
 
 			var draft = JSON.parse( xhr.responseText );
-			currentDraftId = draft.draft_id;
-			draftFiles = draft.files;
-			setDraftIdInUrl( currentDraftId );
-
 			setStatus( 'ua-upload-status',
-				'Draft created. ' + draftFiles.length + ' track(s) analyzed.', 'success' );
+				'Draft created. ' + draft.files.length + ' track(s) analyzed. Creating draft page...', 'success' );
 
-			renderReview( draft );
-			showStep( 'ua-step-review' );
+			createReleaseDraftPage( draft );
 		} );
 
 		xhr.addEventListener( 'error', function () {
@@ -224,351 +180,94 @@
 		xhr.send( formData );
 	}
 
-	// -- Step 2: Review & Track Ordering --
+	// -- Create ReleaseDraft wiki page and redirect --
 
-	function renderReview( draft ) {
-		// Show analysis summary
-		var info = el( 'ua-draft-info' );
-		var totalDuration = 0;
-		var totalSize = 0;
-		var formats = {};
+	function createReleaseDraftPage( draft ) {
+		var draftId = draft.draft_id;
+		var pageName = 'ReleaseDraft:' + draftId;
 
-		draft.files.forEach( function ( f ) {
-			if ( f.duration_seconds ) {
-				totalDuration += f.duration_seconds;
-			}
-			if ( f.size_bytes ) {
-				totalSize += f.size_bytes;
-			}
-			formats[ f.format ] = ( formats[ f.format ] || 0 ) + 1;
+		// Build initial YAML from delivery-kid analysis
+		var tracks = ( draft.files || [] ).map( function ( f ) {
+			var title = f.detected_title || f.original_filename.replace( /\.[^.]+$/, '' );
+			return {
+				filename: f.original_filename,
+				title: title,
+				format: f.format || '',
+				duration: f.duration_seconds || null,
+				size_bytes: f.size_bytes || null,
+				metadata: ''
+			};
 		} );
 
-		var formatSummary = Object.keys( formats ).map( function ( fmt ) {
-			return formats[ fmt ] + ' ' + fmt;
-		} ).join( ', ' );
+		var yaml = buildYaml( draftId, tracks );
 
-		info.innerHTML =
-			'<p>' + draft.files.length + ' tracks &middot; ' +
-			formatDuration( totalDuration ) + ' total &middot; ' +
-			formatSize( totalSize ) + ' &middot; ' + formatSummary + '</p>' +
-			'<p class="uc-draft-expires">Draft expires: ' +
-			new Date( draft.expires_at ).toLocaleString() + '</p>';
-
-		// Render track list
-		renderTrackList( draft.files );
-	}
-
-	function renderTrackList( files ) {
-		var container = el( 'ua-track-list' );
-		container.innerHTML = '';
-
-		files.forEach( function ( file, idx ) {
-			var row = document.createElement( 'div' );
-			row.className = 'ua-track-row';
-			row.draggable = true;
-			row.dataset.idx = idx;
-
-			var title = file.detected_title || file.original_filename.replace( /\.[^.]+$/, '' );
-
-			row.innerHTML =
-				'<span class="ua-track-handle" title="Drag to reorder">&#9776;</span>' +
-				'<span class="ua-track-num">' + ( idx + 1 ) + '</span>' +
-				'<input type="text" class="ua-track-title cdx-text-input__input" ' +
-					'value="' + mw.html.escape( title ) + '" ' +
-					'data-filename="' + mw.html.escape( file.original_filename ) + '">' +
-				'<span class="ua-track-meta">' +
-					mw.html.escape( file.format ) + ' &middot; ' +
-					formatDuration( file.duration_seconds ) + ' &middot; ' +
-					formatSize( file.size_bytes ) +
-				'</span>';
-
-			container.appendChild( row );
-		} );
-
-		initDragReorder( container );
-	}
-
-	function initDragReorder( container ) {
-		var dragSrc = null;
-
-		container.addEventListener( 'dragstart', function ( e ) {
-			var row = e.target.closest( '.ua-track-row' );
-			if ( !row ) {
-				return;
+		var api = new mw.Api();
+		api.postWithEditToken( {
+			action: 'edit',
+			title: pageName,
+			text: yaml,
+			summary: 'New album draft: ' + draft.files.length + ' tracks uploaded',
+			createonly: true
+		} ).then( function () {
+			// Redirect to the new draft page
+			window.location.href = mw.util.getUrl( pageName );
+		} ).fail( function ( code, result ) {
+			if ( code === 'articleexists' ) {
+				// Draft page already exists (maybe re-upload?) — just redirect
+				window.location.href = mw.util.getUrl( pageName );
+			} else {
+				setStatus( 'ua-upload-status',
+					'Failed to create draft page: ' + ( result.error ? result.error.info : code ), 'error' );
+				el( 'ua-upload-btn' ).disabled = false;
 			}
-			dragSrc = row;
-			row.classList.add( 'ua-track-dragging' );
-			e.dataTransfer.effectAllowed = 'move';
-		} );
-
-		container.addEventListener( 'dragover', function ( e ) {
-			e.preventDefault();
-			e.dataTransfer.dropEffect = 'move';
-			var row = e.target.closest( '.ua-track-row' );
-			if ( row && row !== dragSrc ) {
-				var rect = row.getBoundingClientRect();
-				var midY = rect.top + rect.height / 2;
-				if ( e.clientY < midY ) {
-					container.insertBefore( dragSrc, row );
-				} else {
-					container.insertBefore( dragSrc, row.nextSibling );
-				}
-			}
-		} );
-
-		container.addEventListener( 'dragend', function () {
-			if ( dragSrc ) {
-				dragSrc.classList.remove( 'ua-track-dragging' );
-				dragSrc = null;
-			}
-			renumberTracks( container );
 		} );
 	}
 
-	function renumberTracks( container ) {
-		var rows = container.querySelectorAll( '.ua-track-row' );
-		rows.forEach( function ( row, idx ) {
-			row.dataset.idx = idx;
-			row.querySelector( '.ua-track-num' ).textContent = idx + 1;
+	function buildYaml( draftId, tracks ) {
+		var lines = [];
+		lines.push( 'draft_id: ' + draftId );
+		lines.push( 'type: album' );
+		lines.push( 'status: draft' );
+		lines.push( 'blockheight: null' );
+		lines.push( 'album:' );
+		lines.push( '    title: ""' );
+		lines.push( '    artist: ""' );
+		lines.push( '    year: ""' );
+		lines.push( '    description: ""' );
+		lines.push( 'tracks:' );
+
+		tracks.forEach( function ( track ) {
+			lines.push( '    -' );
+			lines.push( '        filename: ' + quote( track.filename ) );
+			lines.push( '        title: ' + quote( track.title ) );
+			if ( track.format ) {
+				lines.push( '        format: ' + quote( track.format ) );
+			}
+			if ( track.duration ) {
+				lines.push( '        duration: ' + track.duration );
+			}
+			if ( track.size_bytes ) {
+				lines.push( '        size_bytes: ' + track.size_bytes );
+			}
+			lines.push( '        metadata: ""' );
 		} );
+
+		lines.push( 'result:' );
+		lines.push( '    cid: null' );
+		lines.push( '    gateway_url: null' );
+
+		return lines.join( '\n' ) + '\n';
 	}
 
-	function getTrackOrder() {
-		var rows = el( 'ua-track-list' ).querySelectorAll( '.ua-track-row' );
-		var tracks = [];
-		rows.forEach( function ( row ) {
-			var input = row.querySelector( '.ua-track-title' );
-			tracks.push( {
-				filename: input.dataset.filename,
-				title: input.value
-			} );
-		} );
-		return tracks;
-	}
-
-	function initReviewStep() {
-		el( 'ua-finalize-btn' ).addEventListener( 'click', function () {
-			var albumTitle = el( 'ua-album-title' ).value.trim();
-			var artist = el( 'ua-artist' ).value.trim();
-
-			if ( !albumTitle ) {
-				setStatus( 'ua-upload-status', 'Album title is required.', 'error' );
-				el( 'ua-album-title' ).focus();
-				return;
-			}
-			if ( !artist ) {
-				setStatus( 'ua-upload-status', 'Artist is required.', 'error' );
-				el( 'ua-artist' ).focus();
-				return;
-			}
-
-			startFinalization();
-		} );
-
-		el( 'ua-delete-draft-btn' ).addEventListener( 'click', function () {
-			if ( !currentDraftId || !confirm( 'Delete this draft? This cannot be undone.' ) ) {
-				return;
-			}
-			fetch( API_URL + '/draft-album/' + currentDraftId, {
-				method: 'DELETE',
-				headers: AUTH_HEADERS
-			} ).then( function () {
-				currentDraftId = null;
-				draftFiles = [];
-				setDraftIdInUrl( null );
-				showStep( 'ua-step-upload' );
-				setStatus( 'ua-upload-status', 'Draft deleted.', '' );
-			} );
-		} );
-	}
-
-	// -- Step 3: Finalize --
-
-	function startFinalization() {
-		if ( !currentDraftId ) {
-			return;
+	function quote( val ) {
+		if ( val === '' || val === null || val === undefined ) {
+			return '""';
 		}
-
-		showStep( 'ua-step-progress' );
-		setProgress( 0 );
-		setStatus( 'ua-progress-status', 'Starting album finalization...', '' );
-
-		var headers = Object.assign( {}, AUTH_HEADERS, {
-			'Content-Type': 'application/json'
-		} );
-
-		var body = JSON.stringify( {
-			album_title: el( 'ua-album-title' ).value.trim(),
-			artist: el( 'ua-artist' ).value.trim(),
-			year: el( 'ua-year' ).value.trim() || null,
-			description: el( 'ua-description' ).value.trim() || null,
-			tracks: getTrackOrder()
-		} );
-
-		fetch( API_URL + '/draft-album/' + currentDraftId + '/finalize', {
-			method: 'POST',
-			headers: headers,
-			body: body
-		} ).then( function ( resp ) {
-			if ( !resp.ok ) {
-				return resp.json().then( function ( err ) {
-					throw new Error( err.detail || resp.statusText );
-				} );
-			}
-			return readSSEStream( resp );
-		} ).catch( function ( err ) {
-			setStatus( 'ua-progress-status', 'Error: ' + err.message, 'error' );
-		} );
-	}
-
-	function readSSEStream( resp ) {
-		var reader = resp.body.getReader();
-		var decoder = new TextDecoder();
-		var buffer = '';
-
-		function pump() {
-			return reader.read().then( function ( result ) {
-				if ( result.done ) {
-					return;
-				}
-
-				buffer += decoder.decode( result.value, { stream: true } );
-				var lines = buffer.split( '\n' );
-				buffer = lines.pop();
-
-				var currentEvent = '';
-				for ( var i = 0; i < lines.length; i++ ) {
-					var line = lines[ i ].trim();
-					if ( line.indexOf( 'event:' ) === 0 ) {
-						currentEvent = line.slice( 6 ).trim();
-					} else if ( line.indexOf( 'data:' ) === 0 ) {
-						var data = line.slice( 5 ).trim();
-						try {
-							handleSSEEvent( currentEvent, JSON.parse( data ) );
-						} catch ( e ) {
-							// skip malformed
-						}
-					}
-				}
-
-				return pump();
-			} );
+		val = String( val );
+		if ( /[:#\[\]{}&*!|>'"%@`\n]/.test( val ) || val.trim() !== val ) {
+			return '"' + val.replace( /\\/g, '\\\\' ).replace( /"/g, '\\"' ).replace( /\n/g, '\\n' ) + '"';
 		}
-
-		return pump();
-	}
-
-	function handleSSEEvent( event, data ) {
-		if ( event === 'progress' ) {
-			setProgress( data.progress || 0 );
-			var msg = data.message || '';
-			if ( data.track ) {
-				msg += ' (' + data.track + ')';
-			}
-			setStatus( 'ua-progress-status', msg, '' );
-		} else if ( event === 'warning' ) {
-			setStatus( 'ua-progress-status', 'Warning: ' + data.message, 'warning' );
-		} else if ( event === 'complete' ) {
-			setProgress( 100 );
-			setStatus( 'ua-progress-status', 'Album pinned!', 'success' );
-			renderResult( data );
-			currentDraftId = null;
-			draftFiles = [];
-			setDraftIdInUrl( null );
-		} else if ( event === 'error' ) {
-			setStatus( 'ua-progress-status',
-				'Error: ' + ( data.message || 'Unknown error' ), 'error' );
-		}
-	}
-
-	function setProgress( pct ) {
-		var fill = document.querySelector( '#ua-progress-bar .uc-progress-fill' );
-		if ( fill ) {
-			fill.style.width = pct + '%';
-		}
-	}
-
-	function renderResult( data ) {
-		var resultEl = el( 'ua-result' );
-		var releaseUrl = mw.util.getUrl( 'Release:' + data.cid );
-
-		var html = '<div class="uc-result-card">';
-		html += '<h4>' + mw.html.escape( data.album_title || 'Album' ) +
-			' &mdash; ' + mw.html.escape( data.artist || '' ) + '</h4>';
-		html += '<table class="wikitable">';
-		html += '<tr><th>CID</th><td class="release-cid-cell">' +
-			mw.html.escape( data.cid ) + '</td></tr>';
-		if ( data.gateway_url ) {
-			html += '<tr><th>Gateway</th><td><a href="' + mw.html.escape( data.gateway_url ) +
-				'" target="_blank">' + mw.html.escape( data.gateway_url ) + '</a></td></tr>';
-		}
-		html += '<tr><th>Pinata</th><td>' + ( data.pinata ? 'Yes' : 'No' ) + '</td></tr>';
-		html += '</table>';
-
-		// Track listing
-		if ( data.tracks && data.tracks.length ) {
-			html += '<h5>Tracks</h5><ol>';
-			data.tracks.forEach( function ( t ) {
-				html += '<li>' + mw.html.escape( t.title || t.filename ) + '</li>';
-			} );
-			html += '</ol>';
-		}
-
-		html += '<p><a href="' + mw.html.escape( releaseUrl ) +
-			'" class="cdx-button cdx-button--action-progressive">Create Release Page</a></p>';
-		html += '<button id="ua-start-over" class="cdx-button">Upload Another Album</button>';
-		html += '</div>';
-
-		resultEl.innerHTML = html;
-
-		el( 'ua-start-over' ).addEventListener( 'click', function () {
-			resultEl.innerHTML = '';
-			showStep( 'ua-step-upload' );
-		} );
-	}
-
-	// -- Resume draft --
-
-	function resumeDraft( draftId ) {
-		setStatus( 'ua-upload-status', 'Resuming draft ' + draftId.slice( 0, 8 ) + '...', '' );
-
-		fetch( API_URL + '/draft-album/' + draftId, {
-			headers: AUTH_HEADERS
-		} ).then( function ( resp ) {
-			if ( resp.status === 410 ) {
-				setStatus( 'ua-upload-status', 'That draft has expired. Upload again.', 'error' );
-				setDraftIdInUrl( null );
-				return;
-			}
-			if ( resp.status === 404 ) {
-				setStatus( 'ua-upload-status', 'Draft not found. It may have been deleted or finalized.', 'error' );
-				setDraftIdInUrl( null );
-				return;
-			}
-			if ( !resp.ok ) {
-				return resp.json().then( function ( err ) {
-					var msg = ( err.detail && typeof err.detail === 'string' ) ? err.detail : JSON.stringify( err );
-					setStatus( 'ua-upload-status', 'Could not resume draft: ' + msg, 'error' );
-					setDraftIdInUrl( null );
-				} );
-			}
-			return resp.json();
-		} ).then( function ( draft ) {
-			if ( !draft ) {
-				return;
-			}
-			currentDraftId = draft.draft_id;
-			draftFiles = draft.files;
-
-			setStatus( 'ua-upload-status',
-				'Draft resumed. ' + draftFiles.length + ' track(s).', 'success' );
-
-			renderReview( draft );
-			showStep( 'ua-step-review' );
-		} ).catch( function ( err ) {
-			setStatus( 'ua-upload-status', 'Network error resuming draft: ' + err.message, 'error' );
-			setDraftIdInUrl( null );
-		} );
+		return val;
 	}
 
 	// -- Init --
@@ -581,15 +280,8 @@
 		}
 
 		initUploadStep();
-		initReviewStep();
-
-		// Check for draft ID in URL (resume after page reload or shared link)
-		var urlDraftId = getDraftIdFromUrl();
-		if ( urlDraftId ) {
-			resumeDraft( urlDraftId );
-		}
 	}
 
-	mw.loader.using( 'mediawiki.util' ).then( init );
+	mw.loader.using( [ 'mediawiki.util', 'mediawiki.api' ] ).then( init );
 
 }() );

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
@@ -164,14 +164,24 @@
 			progressBar.style.display = 'none';
 
 			if ( xhr.status !== 200 ) {
-				var err;
+				var errMsg;
 				try {
-					err = JSON.parse( xhr.responseText );
+					var err = JSON.parse( xhr.responseText );
+					var detail = err.detail;
+					if ( typeof detail === 'string' ) {
+						errMsg = detail;
+					} else if ( detail && detail.error ) {
+						errMsg = detail.error;
+					} else if ( Array.isArray( detail ) ) {
+						errMsg = detail.map( function ( d ) { return d.msg || JSON.stringify( d ); } ).join( '; ' );
+					} else {
+						errMsg = JSON.stringify( err );
+					}
 				} catch ( e ) {
-					err = { detail: xhr.statusText };
+					errMsg = xhr.status + ' ' + xhr.statusText + ': ' + xhr.responseText.slice( 0, 200 );
 				}
 				setStatus( 'ua-upload-status',
-					'Upload failed: ' + ( err.detail || xhr.statusText ), 'error' );
+					'Upload failed (' + xhr.status + '): ' + errMsg, 'error' );
 				uploadBtn.disabled = false;
 				return;
 			}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.uploadAlbum.js
@@ -1,0 +1,515 @@
+/**
+ * Upload Album — direct upload to delivery-kid from browser.
+ *
+ * Three-step flow using /draft-album:
+ * 1. Upload audio + cover → delivery-kid analyzes tracks
+ * 2. Review: reorder tracks, edit titles, set album metadata
+ * 3. Finalize → transcode FLAC/WAV→OGG, embed tags, pin to IPFS
+ */
+( function () {
+	'use strict';
+
+	var API_URL = mw.config.get( 'wgDeliveryKidUrl' );
+	var AUTH_HEADERS = {
+		'X-Upload-Token': mw.config.get( 'wgUploadToken' ),
+		'X-Upload-User': mw.config.get( 'wgUploadUser' ),
+		'X-Upload-Timestamp': String( mw.config.get( 'wgUploadTimestamp' ) )
+	};
+
+	var currentDraftId = null;
+	var draftFiles = []; // analyzed files from draft response
+
+	// -- Helpers --
+
+	function el( id ) {
+		return document.getElementById( id );
+	}
+
+	function setStatus( elementId, message, type ) {
+		var e = el( elementId );
+		e.textContent = message;
+		e.className = 'uc-status' + ( type ? ' uc-status-' + type : '' );
+	}
+
+	function showStep( stepId ) {
+		document.querySelectorAll( '.uc-step' ).forEach( function ( s ) {
+			s.classList.remove( 'uc-step-active' );
+		} );
+		el( stepId ).classList.add( 'uc-step-active' );
+	}
+
+	function formatSize( bytes ) {
+		var units = [ 'B', 'KB', 'MB', 'GB' ];
+		var size = bytes;
+		var i = 0;
+		while ( size >= 1024 && i < units.length - 1 ) {
+			size /= 1024;
+			i++;
+		}
+		return size.toFixed( 1 ) + ' ' + units[ i ];
+	}
+
+	function formatDuration( seconds ) {
+		if ( !seconds ) {
+			return '';
+		}
+		var m = Math.floor( seconds / 60 );
+		var s = Math.floor( seconds % 60 );
+		return m + ':' + ( s < 10 ? '0' : '' ) + s;
+	}
+
+	// -- Step 1: File Upload --
+
+	function initUploadStep() {
+		var dropzone = el( 'ua-dropzone' );
+		var fileInput = el( 'ua-file-input' );
+		var fileList = el( 'ua-file-list' );
+		var uploadBtn = el( 'ua-upload-btn' );
+		var selectedFiles = [];
+
+		dropzone.addEventListener( 'click', function () {
+			fileInput.click();
+		} );
+
+		dropzone.addEventListener( 'dragover', function ( e ) {
+			e.preventDefault();
+			dropzone.classList.add( 'uc-dropzone-active' );
+		} );
+
+		dropzone.addEventListener( 'dragleave', function () {
+			dropzone.classList.remove( 'uc-dropzone-active' );
+		} );
+
+		dropzone.addEventListener( 'drop', function ( e ) {
+			e.preventDefault();
+			dropzone.classList.remove( 'uc-dropzone-active' );
+			addFiles( e.dataTransfer.files );
+		} );
+
+		fileInput.addEventListener( 'change', function () {
+			addFiles( fileInput.files );
+			fileInput.value = '';
+		} );
+
+		function addFiles( newFiles ) {
+			for ( var i = 0; i < newFiles.length; i++ ) {
+				selectedFiles.push( newFiles[ i ] );
+			}
+			renderFileList();
+		}
+
+		function renderFileList() {
+			fileList.innerHTML = '';
+			selectedFiles.forEach( function ( file, idx ) {
+				var item = document.createElement( 'div' );
+				item.className = 'uc-file-item';
+				item.innerHTML =
+					'<span class="uc-file-name">' + mw.html.escape( file.name ) + '</span>' +
+					'<span class="uc-file-size">' + formatSize( file.size ) + '</span>' +
+					'<button class="uc-file-remove" data-idx="' + idx + '">&times;</button>';
+				fileList.appendChild( item );
+			} );
+
+			fileList.querySelectorAll( '.uc-file-remove' ).forEach( function ( btn ) {
+				btn.addEventListener( 'click', function () {
+					selectedFiles.splice( parseInt( btn.dataset.idx ), 1 );
+					renderFileList();
+				} );
+			} );
+
+			uploadBtn.disabled = selectedFiles.length === 0;
+		}
+
+		uploadBtn.addEventListener( 'click', function () {
+			if ( selectedFiles.length === 0 ) {
+				return;
+			}
+			doUpload( selectedFiles );
+		} );
+	}
+
+	function doUpload( files ) {
+		var uploadBtn = el( 'ua-upload-btn' );
+		var progressBar = el( 'ua-upload-progress' );
+		var progressFill = progressBar.querySelector( '.uc-progress-fill' );
+
+		uploadBtn.disabled = true;
+		progressBar.style.display = '';
+		setStatus( 'ua-upload-status', 'Uploading ' + files.length + ' file(s)...', '' );
+
+		var formData = new FormData();
+		files.forEach( function ( file ) {
+			formData.append( 'files', file );
+		} );
+
+		var xhr = new XMLHttpRequest();
+		xhr.open( 'POST', API_URL + '/draft-album' );
+
+		// Set auth headers
+		Object.keys( AUTH_HEADERS ).forEach( function ( key ) {
+			xhr.setRequestHeader( key, AUTH_HEADERS[ key ] );
+		} );
+
+		xhr.upload.addEventListener( 'progress', function ( e ) {
+			if ( e.lengthComputable ) {
+				var pct = Math.round( ( e.loaded / e.total ) * 100 );
+				progressFill.style.width = pct + '%';
+				setStatus( 'ua-upload-status',
+					'Uploading... ' + formatSize( e.loaded ) + ' / ' + formatSize( e.total ) +
+					' (' + pct + '%)', '' );
+			}
+		} );
+
+		xhr.addEventListener( 'load', function () {
+			progressBar.style.display = 'none';
+
+			if ( xhr.status !== 200 ) {
+				var err;
+				try {
+					err = JSON.parse( xhr.responseText );
+				} catch ( e ) {
+					err = { detail: xhr.statusText };
+				}
+				setStatus( 'ua-upload-status',
+					'Upload failed: ' + ( err.detail || xhr.statusText ), 'error' );
+				uploadBtn.disabled = false;
+				return;
+			}
+
+			var draft = JSON.parse( xhr.responseText );
+			currentDraftId = draft.draft_id;
+			draftFiles = draft.files;
+
+			setStatus( 'ua-upload-status',
+				'Draft created. ' + draftFiles.length + ' track(s) analyzed.', 'success' );
+
+			renderReview( draft );
+			showStep( 'ua-step-review' );
+		} );
+
+		xhr.addEventListener( 'error', function () {
+			progressBar.style.display = 'none';
+			setStatus( 'ua-upload-status', 'Network error during upload.', 'error' );
+			uploadBtn.disabled = false;
+		} );
+
+		xhr.send( formData );
+	}
+
+	// -- Step 2: Review & Track Ordering --
+
+	function renderReview( draft ) {
+		// Show analysis summary
+		var info = el( 'ua-draft-info' );
+		var totalDuration = 0;
+		var totalSize = 0;
+		var formats = {};
+
+		draft.files.forEach( function ( f ) {
+			if ( f.duration_seconds ) {
+				totalDuration += f.duration_seconds;
+			}
+			if ( f.size_bytes ) {
+				totalSize += f.size_bytes;
+			}
+			formats[ f.format ] = ( formats[ f.format ] || 0 ) + 1;
+		} );
+
+		var formatSummary = Object.keys( formats ).map( function ( fmt ) {
+			return formats[ fmt ] + ' ' + fmt;
+		} ).join( ', ' );
+
+		info.innerHTML =
+			'<p>' + draft.files.length + ' tracks &middot; ' +
+			formatDuration( totalDuration ) + ' total &middot; ' +
+			formatSize( totalSize ) + ' &middot; ' + formatSummary + '</p>' +
+			'<p class="uc-draft-expires">Draft expires: ' +
+			new Date( draft.expires_at ).toLocaleString() + '</p>';
+
+		// Render track list
+		renderTrackList( draft.files );
+	}
+
+	function renderTrackList( files ) {
+		var container = el( 'ua-track-list' );
+		container.innerHTML = '';
+
+		files.forEach( function ( file, idx ) {
+			var row = document.createElement( 'div' );
+			row.className = 'ua-track-row';
+			row.draggable = true;
+			row.dataset.idx = idx;
+
+			var title = file.detected_title || file.original_filename.replace( /\.[^.]+$/, '' );
+
+			row.innerHTML =
+				'<span class="ua-track-handle" title="Drag to reorder">&#9776;</span>' +
+				'<span class="ua-track-num">' + ( idx + 1 ) + '</span>' +
+				'<input type="text" class="ua-track-title cdx-text-input__input" ' +
+					'value="' + mw.html.escape( title ) + '" ' +
+					'data-filename="' + mw.html.escape( file.original_filename ) + '">' +
+				'<span class="ua-track-meta">' +
+					mw.html.escape( file.format ) + ' &middot; ' +
+					formatDuration( file.duration_seconds ) + ' &middot; ' +
+					formatSize( file.size_bytes ) +
+				'</span>';
+
+			container.appendChild( row );
+		} );
+
+		initDragReorder( container );
+	}
+
+	function initDragReorder( container ) {
+		var dragSrc = null;
+
+		container.addEventListener( 'dragstart', function ( e ) {
+			var row = e.target.closest( '.ua-track-row' );
+			if ( !row ) {
+				return;
+			}
+			dragSrc = row;
+			row.classList.add( 'ua-track-dragging' );
+			e.dataTransfer.effectAllowed = 'move';
+		} );
+
+		container.addEventListener( 'dragover', function ( e ) {
+			e.preventDefault();
+			e.dataTransfer.dropEffect = 'move';
+			var row = e.target.closest( '.ua-track-row' );
+			if ( row && row !== dragSrc ) {
+				var rect = row.getBoundingClientRect();
+				var midY = rect.top + rect.height / 2;
+				if ( e.clientY < midY ) {
+					container.insertBefore( dragSrc, row );
+				} else {
+					container.insertBefore( dragSrc, row.nextSibling );
+				}
+			}
+		} );
+
+		container.addEventListener( 'dragend', function () {
+			if ( dragSrc ) {
+				dragSrc.classList.remove( 'ua-track-dragging' );
+				dragSrc = null;
+			}
+			renumberTracks( container );
+		} );
+	}
+
+	function renumberTracks( container ) {
+		var rows = container.querySelectorAll( '.ua-track-row' );
+		rows.forEach( function ( row, idx ) {
+			row.dataset.idx = idx;
+			row.querySelector( '.ua-track-num' ).textContent = idx + 1;
+		} );
+	}
+
+	function getTrackOrder() {
+		var rows = el( 'ua-track-list' ).querySelectorAll( '.ua-track-row' );
+		var tracks = [];
+		rows.forEach( function ( row ) {
+			var input = row.querySelector( '.ua-track-title' );
+			tracks.push( {
+				filename: input.dataset.filename,
+				title: input.value
+			} );
+		} );
+		return tracks;
+	}
+
+	function initReviewStep() {
+		el( 'ua-finalize-btn' ).addEventListener( 'click', function () {
+			var albumTitle = el( 'ua-album-title' ).value.trim();
+			var artist = el( 'ua-artist' ).value.trim();
+
+			if ( !albumTitle ) {
+				setStatus( 'ua-upload-status', 'Album title is required.', 'error' );
+				el( 'ua-album-title' ).focus();
+				return;
+			}
+			if ( !artist ) {
+				setStatus( 'ua-upload-status', 'Artist is required.', 'error' );
+				el( 'ua-artist' ).focus();
+				return;
+			}
+
+			startFinalization();
+		} );
+
+		el( 'ua-delete-draft-btn' ).addEventListener( 'click', function () {
+			if ( !currentDraftId || !confirm( 'Delete this draft? This cannot be undone.' ) ) {
+				return;
+			}
+			fetch( API_URL + '/draft-album/' + currentDraftId, {
+				method: 'DELETE',
+				headers: AUTH_HEADERS
+			} ).then( function () {
+				currentDraftId = null;
+				draftFiles = [];
+				showStep( 'ua-step-upload' );
+				setStatus( 'ua-upload-status', 'Draft deleted.', '' );
+			} );
+		} );
+	}
+
+	// -- Step 3: Finalize --
+
+	function startFinalization() {
+		if ( !currentDraftId ) {
+			return;
+		}
+
+		showStep( 'ua-step-progress' );
+		setProgress( 0 );
+		setStatus( 'ua-progress-status', 'Starting album finalization...', '' );
+
+		var headers = Object.assign( {}, AUTH_HEADERS, {
+			'Content-Type': 'application/json'
+		} );
+
+		var body = JSON.stringify( {
+			album_title: el( 'ua-album-title' ).value.trim(),
+			artist: el( 'ua-artist' ).value.trim(),
+			year: el( 'ua-year' ).value.trim() || null,
+			description: el( 'ua-description' ).value.trim() || null,
+			tracks: getTrackOrder()
+		} );
+
+		fetch( API_URL + '/draft-album/' + currentDraftId + '/finalize', {
+			method: 'POST',
+			headers: headers,
+			body: body
+		} ).then( function ( resp ) {
+			if ( !resp.ok ) {
+				return resp.json().then( function ( err ) {
+					throw new Error( err.detail || resp.statusText );
+				} );
+			}
+			return readSSEStream( resp );
+		} ).catch( function ( err ) {
+			setStatus( 'ua-progress-status', 'Error: ' + err.message, 'error' );
+		} );
+	}
+
+	function readSSEStream( resp ) {
+		var reader = resp.body.getReader();
+		var decoder = new TextDecoder();
+		var buffer = '';
+
+		function pump() {
+			return reader.read().then( function ( result ) {
+				if ( result.done ) {
+					return;
+				}
+
+				buffer += decoder.decode( result.value, { stream: true } );
+				var lines = buffer.split( '\n' );
+				buffer = lines.pop();
+
+				var currentEvent = '';
+				for ( var i = 0; i < lines.length; i++ ) {
+					var line = lines[ i ].trim();
+					if ( line.indexOf( 'event:' ) === 0 ) {
+						currentEvent = line.slice( 6 ).trim();
+					} else if ( line.indexOf( 'data:' ) === 0 ) {
+						var data = line.slice( 5 ).trim();
+						try {
+							handleSSEEvent( currentEvent, JSON.parse( data ) );
+						} catch ( e ) {
+							// skip malformed
+						}
+					}
+				}
+
+				return pump();
+			} );
+		}
+
+		return pump();
+	}
+
+	function handleSSEEvent( event, data ) {
+		if ( event === 'progress' ) {
+			setProgress( data.progress || 0 );
+			var msg = data.message || '';
+			if ( data.track ) {
+				msg += ' (' + data.track + ')';
+			}
+			setStatus( 'ua-progress-status', msg, '' );
+		} else if ( event === 'warning' ) {
+			setStatus( 'ua-progress-status', 'Warning: ' + data.message, 'warning' );
+		} else if ( event === 'complete' ) {
+			setProgress( 100 );
+			setStatus( 'ua-progress-status', 'Album pinned!', 'success' );
+			renderResult( data );
+			currentDraftId = null;
+			draftFiles = [];
+		} else if ( event === 'error' ) {
+			setStatus( 'ua-progress-status',
+				'Error: ' + ( data.message || 'Unknown error' ), 'error' );
+		}
+	}
+
+	function setProgress( pct ) {
+		var fill = document.querySelector( '#ua-progress-bar .uc-progress-fill' );
+		if ( fill ) {
+			fill.style.width = pct + '%';
+		}
+	}
+
+	function renderResult( data ) {
+		var resultEl = el( 'ua-result' );
+		var releaseUrl = mw.util.getUrl( 'Release:' + data.cid );
+
+		var html = '<div class="uc-result-card">';
+		html += '<h4>' + mw.html.escape( data.album_title || 'Album' ) +
+			' &mdash; ' + mw.html.escape( data.artist || '' ) + '</h4>';
+		html += '<table class="wikitable">';
+		html += '<tr><th>CID</th><td class="release-cid-cell">' +
+			mw.html.escape( data.cid ) + '</td></tr>';
+		if ( data.gateway_url ) {
+			html += '<tr><th>Gateway</th><td><a href="' + mw.html.escape( data.gateway_url ) +
+				'" target="_blank">' + mw.html.escape( data.gateway_url ) + '</a></td></tr>';
+		}
+		html += '<tr><th>Pinata</th><td>' + ( data.pinata ? 'Yes' : 'No' ) + '</td></tr>';
+		html += '</table>';
+
+		// Track listing
+		if ( data.tracks && data.tracks.length ) {
+			html += '<h5>Tracks</h5><ol>';
+			data.tracks.forEach( function ( t ) {
+				html += '<li>' + mw.html.escape( t.title || t.filename ) + '</li>';
+			} );
+			html += '</ol>';
+		}
+
+		html += '<p><a href="' + mw.html.escape( releaseUrl ) +
+			'" class="cdx-button cdx-button--action-progressive">Create Release Page</a></p>';
+		html += '<button id="ua-start-over" class="cdx-button">Upload Another Album</button>';
+		html += '</div>';
+
+		resultEl.innerHTML = html;
+
+		el( 'ua-start-over' ).addEventListener( 'click', function () {
+			resultEl.innerHTML = '';
+			showStep( 'ua-step-upload' );
+		} );
+	}
+
+	// -- Init --
+
+	function init() {
+		if ( !API_URL ) {
+			el( 'ua-step-upload' ).innerHTML =
+				'<p class="uc-status uc-status-error">Delivery Kid URL not configured.</p>';
+			return;
+		}
+
+		initUploadStep();
+		initReviewStep();
+	}
+
+	mw.loader.using( 'mediawiki.util' ).then( init );
+
+}() );

--- a/extensions/PickiPediaReleases/src/Hooks.php
+++ b/extensions/PickiPediaReleases/src/Hooks.php
@@ -10,22 +10,54 @@ namespace MediaWiki\Extension\PickiPediaReleases;
 
 use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
 use MediaWiki\Installer\DatabaseUpdater;
+use MediaWiki\Hook\BeforePageDisplayHook;
+use MediaWiki\Output\OutputPage;
+use Skin;
 
-class Hooks implements LoadExtensionSchemaUpdatesHook {
+class Hooks implements LoadExtensionSchemaUpdatesHook, BeforePageDisplayHook {
 
 	/**
 	 * Handle schema updates
-	 *
-	 * Currently no custom tables needed - releases are stored as page content.
-	 * This hook is reserved for future use (e.g., caching release metadata).
 	 *
 	 * @param DatabaseUpdater $updater
 	 */
 	public function onLoadExtensionSchemaUpdates( $updater ): void {
 		// No schema updates needed at this time
-		// Releases are stored as page content in the Release namespace
+	}
 
-		// Future: Could add a cache table for faster API queries
-		// $updater->addExtensionTable( 'release_cache', __DIR__ . '/../sql/release_cache.sql' );
+	/**
+	 * Inject delivery-kid auth config when viewing ReleaseDraft pages.
+	 *
+	 * The content handler loads the JS module, but HMAC tokens must be
+	 * generated per-request with the current user's identity.
+	 *
+	 * @param OutputPage $out
+	 * @param Skin $skin
+	 */
+	public function onBeforePageDisplay( $out, $skin ): void {
+		$title = $out->getTitle();
+		if ( !$title || $title->getNamespace() !== NS_RELEASEDRAFT ) {
+			return;
+		}
+
+		$config = $out->getConfig();
+		$apiKey = $config->get( 'DeliveryKidApiKey' );
+		$apiUrl = $config->get( 'DeliveryKidUrl' );
+
+		if ( !$apiKey || !$apiUrl ) {
+			return;
+		}
+
+		$user = $out->getUser();
+		$username = $user->getName();
+		$timestamp = (int)( microtime( true ) * 1000 );
+		$token = hash_hmac( 'sha256', "upload:{$username}:{$timestamp}", $apiKey );
+
+		$out->addJsConfigVars( [
+			'wgDeliveryKidUrl' => $apiUrl,
+			'wgUploadToken' => $token,
+			'wgUploadUser' => $username,
+			'wgUploadTimestamp' => $timestamp,
+		] );
 	}
 }

--- a/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
@@ -353,7 +353,7 @@ YAML;
 	 * @return string
 	 */
 	private function renderIpfsLink( string $cid ): string {
-		$gatewayUrl = "https://ipfs.io/ipfs/" . strtolower( $cid );
+		$gatewayUrl = "https://ipfs.io/ipfs/" . $cid;
 		$dweb = "ipfs://{$cid}";
 
 		return Html::rawElement( 'span', [ 'class' => 'release-ipfs-link' ],

--- a/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
@@ -214,7 +214,12 @@ YAML;
 			$html .= Html::openElement( 'tr' );
 			$html .= Html::element( 'th', [], 'BitTorrent' );
 			$html .= Html::rawElement( 'td', [],
-				$this->renderTorrentLink( $data['bittorrent_infohash'], $data['title'] ?? $cid )
+				$this->renderTorrentLink(
+					$data['bittorrent_infohash'],
+					$data['title'] ?? $cid,
+					$data['bittorrent_trackers'] ?? [],
+					$cid
+				)
 			);
 			$html .= Html::closeElement( 'tr' );
 		}
@@ -371,12 +376,21 @@ YAML;
 	 *
 	 * @param string $infohash
 	 * @param string $name
+	 * @param array $trackers
+	 * @param string|null $cid IPFS CID for webseed URL
 	 * @return string
 	 */
-	private function renderTorrentLink( string $infohash, string $name ): string {
+	private function renderTorrentLink( string $infohash, string $name, array $trackers = [], ?string $cid = null ): string {
 		$magnetUri = "magnet:?xt=urn:btih:{$infohash}";
 		if ( $name ) {
 			$magnetUri .= "&dn=" . urlencode( $name );
+		}
+		foreach ( $trackers as $tracker ) {
+			$magnetUri .= "&tr=" . urlencode( $tracker );
+		}
+		if ( $cid ) {
+			$normalizedCid = str_starts_with( $cid, 'Bafy' ) ? strtolower( $cid ) : $cid;
+			$magnetUri .= "&ws=" . urlencode( "https://ipfs.delivery-kid.cryptograss.live/ipfs/{$normalizedCid}/" );
 		}
 
 		return Html::rawElement( 'span', [ 'class' => 'release-torrent-link' ],

--- a/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
@@ -175,6 +175,11 @@ YAML;
 			] );
 		}
 
+		// Title from YAML
+		if ( !empty( $data['title'] ) ) {
+			$html .= Html::element( 'h2', [ 'class' => 'release-title' ], $data['title'] );
+		}
+
 		$html .= Html::openElement( 'table', [ 'class' => 'release-metadata wikitable' ] );
 
 		// CID from page title (primary identifier)

--- a/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
@@ -353,11 +353,14 @@ YAML;
 	 * @return string
 	 */
 	private function renderIpfsLink( string $cid ): string {
-		$gatewayUrl = "https://ipfs.io/ipfs/" . $cid;
-		$dweb = "ipfs://{$cid}";
+		// CIDv1 (bafy...) is Base32 lowercase; MediaWiki capitalizes page titles,
+		// so we must lowercase it back. CIDv0 (Qm...) is Base58, case-sensitive.
+		$normalizedCid = str_starts_with( $cid, 'Bafy' ) ? strtolower( $cid ) : $cid;
+		$gatewayUrl = "https://ipfs.io/ipfs/" . $normalizedCid;
+		$dweb = "ipfs://{$normalizedCid}";
 
 		return Html::rawElement( 'span', [ 'class' => 'release-ipfs-link' ],
-			Html::element( 'code', [], $cid ) . ' ' .
+			Html::element( 'code', [], $normalizedCid ) . ' ' .
 			Html::element( 'a', [ 'href' => $gatewayUrl, 'rel' => 'nofollow' ], '[gateway]' ) . ' ' .
 			Html::element( 'a', [ 'href' => $dweb ], '[ipfs://]' )
 		);

--- a/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
@@ -348,7 +348,7 @@ YAML;
 	 * @return string
 	 */
 	private function renderIpfsLink( string $cid ): string {
-		$gatewayUrl = "https://ipfs.io/ipfs/{$cid}";
+		$gatewayUrl = "https://ipfs.io/ipfs/" . strtolower( $cid );
 		$dweb = "ipfs://{$cid}";
 
 		return Html::rawElement( 'span', [ 'class' => 'release-ipfs-link' ],

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContent.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContent.php
@@ -17,15 +17,12 @@
 namespace MediaWiki\Extension\PickiPediaReleases;
 
 use Content;
-use MediaWiki\Content\AbstractContent;
+use MediaWiki\Content\TextContent;
 use StatusValue;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
 
-class ReleaseDraftContent extends AbstractContent {
-
-	/** @var string Raw YAML text */
-	private string $yamlText;
+class ReleaseDraftContent extends TextContent {
 
 	/** @var array|null Parsed data, cached */
 	private ?array $parsedData = null;
@@ -34,12 +31,7 @@ class ReleaseDraftContent extends AbstractContent {
 	private ?ParseException $parseError = null;
 
 	public function __construct( string $text ) {
-		parent::__construct( 'release-draft-yaml' );
-		$this->yamlText = $text;
-	}
-
-	public function getText(): string {
-		return $this->yamlText;
+		parent::__construct( $text, 'release-draft-yaml' );
 	}
 
 	public function getData(): array {
@@ -58,7 +50,7 @@ class ReleaseDraftContent extends AbstractContent {
 
 	private function parseYaml(): void {
 		try {
-			$data = Yaml::parse( $this->yamlText );
+			$data = Yaml::parse( $this->getText() );
 			$this->parsedData = is_array( $data ) ? $data : [];
 			$this->parseError = null;
 		} catch ( ParseException $e ) {
@@ -154,10 +146,6 @@ class ReleaseDraftContent extends AbstractContent {
 		return implode( "\n", $parts );
 	}
 
-	public function getWikitextForTransclusion(): string {
-		return $this->yamlText;
-	}
-
 	public function getTextForSummary( $maxLength = 250 ) {
 		$album = $this->getAlbumData();
 		$summary = '';
@@ -166,26 +154,10 @@ class ReleaseDraftContent extends AbstractContent {
 		} elseif ( !empty( $album['title'] ) ) {
 			$summary = $album['title'];
 		}
-		return $summary ? mb_substr( $summary, 0, $maxLength ) : mb_substr( $this->yamlText, 0, $maxLength );
-	}
-
-	public function getNativeData(): string {
-		return $this->yamlText;
-	}
-
-	public function getSize(): int {
-		return strlen( $this->yamlText );
-	}
-
-	public function copy(): Content {
-		return new ReleaseDraftContent( $this->yamlText );
+		return $summary ? mb_substr( $summary, 0, $maxLength ) : mb_substr( $this->getText(), 0, $maxLength );
 	}
 
 	public function isCountable( $hasLinks = null ): bool {
 		return true;
-	}
-
-	public function serialize( $format = null ): string {
-		return $this->yamlText;
 	}
 }

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContent.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContent.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Content class for ReleaseDraft pages with YAML metadata.
+ *
+ * Stores structured data about a draft release:
+ * - delivery-kid draft ID (referencing files on storage)
+ * - type (album, content, etc.)
+ * - status (draft, finalizing, complete)
+ * - blockheight for temporal reference
+ * - type-specific metadata (album info, tracks, etc.)
+ * - result data after finalization (CID, gateway URL)
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+namespace MediaWiki\Extension\PickiPediaReleases;
+
+use Content;
+use MediaWiki\Content\AbstractContent;
+use StatusValue;
+use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Yaml\Exception\ParseException;
+
+class ReleaseDraftContent extends AbstractContent {
+
+	/** @var string Raw YAML text */
+	private string $yamlText;
+
+	/** @var array|null Parsed data, cached */
+	private ?array $parsedData = null;
+
+	/** @var ParseException|null Parse error, if any */
+	private ?ParseException $parseError = null;
+
+	public function __construct( string $text ) {
+		parent::__construct( 'release-draft-yaml' );
+		$this->yamlText = $text;
+	}
+
+	public function getText(): string {
+		return $this->yamlText;
+	}
+
+	public function getData(): array {
+		if ( $this->parsedData === null ) {
+			$this->parseYaml();
+		}
+		return $this->parsedData ?? [];
+	}
+
+	public function getParseError(): ?ParseException {
+		if ( $this->parsedData === null && $this->parseError === null ) {
+			$this->parseYaml();
+		}
+		return $this->parseError;
+	}
+
+	private function parseYaml(): void {
+		try {
+			$data = Yaml::parse( $this->yamlText );
+			$this->parsedData = is_array( $data ) ? $data : [];
+			$this->parseError = null;
+		} catch ( ParseException $e ) {
+			$this->parsedData = [];
+			$this->parseError = $e;
+		}
+	}
+
+	// -- Getters --
+
+	public function getDraftId(): ?string {
+		return $this->getData()['draft_id'] ?? null;
+	}
+
+	public function getDraftType(): string {
+		return $this->getData()['type'] ?? 'album';
+	}
+
+	public function getStatus(): string {
+		return $this->getData()['status'] ?? 'draft';
+	}
+
+	public function getBlockheight(): ?int {
+		$bh = $this->getData()['blockheight'] ?? null;
+		return $bh !== null ? (int)$bh : null;
+	}
+
+	public function getAlbumData(): array {
+		return $this->getData()['album'] ?? [];
+	}
+
+	public function getTracks(): array {
+		return $this->getData()['tracks'] ?? [];
+	}
+
+	public function getResult(): array {
+		return $this->getData()['result'] ?? [];
+	}
+
+	public function getAlbumTitle(): ?string {
+		return $this->getAlbumData()['title'] ?? null;
+	}
+
+	public function getArtist(): ?string {
+		return $this->getAlbumData()['artist'] ?? null;
+	}
+
+	// -- AbstractContent methods --
+
+	public function validate(): StatusValue {
+		$status = StatusValue::newGood();
+
+		if ( $this->getParseError() !== null ) {
+			$status->fatal(
+				'pickipediareleases-invalid-yaml',
+				$this->parseError->getMessage()
+			);
+			return $status;
+		}
+
+		$data = $this->getData();
+		if ( empty( $data['draft_id'] ) ) {
+			$status->fatal( 'releasedraft-missing-draft-id' );
+		}
+		if ( empty( $data['type'] ) ) {
+			$status->fatal( 'releasedraft-missing-type' );
+		}
+
+		return $status;
+	}
+
+	public function isValid(): bool {
+		return $this->validate()->isOK();
+	}
+
+	public function getTextForSearchIndex(): string {
+		$parts = [];
+		$album = $this->getAlbumData();
+		if ( !empty( $album['title'] ) ) {
+			$parts[] = $album['title'];
+		}
+		if ( !empty( $album['artist'] ) ) {
+			$parts[] = $album['artist'];
+		}
+		if ( !empty( $album['description'] ) ) {
+			$parts[] = $album['description'];
+		}
+		foreach ( $this->getTracks() as $track ) {
+			if ( !empty( $track['title'] ) ) {
+				$parts[] = $track['title'];
+			}
+		}
+		return implode( "\n", $parts );
+	}
+
+	public function getWikitextForTransclusion(): string {
+		return $this->yamlText;
+	}
+
+	public function getTextForSummary( $maxLength = 250 ) {
+		$album = $this->getAlbumData();
+		$summary = '';
+		if ( !empty( $album['artist'] ) && !empty( $album['title'] ) ) {
+			$summary = $album['artist'] . ' — ' . $album['title'];
+		} elseif ( !empty( $album['title'] ) ) {
+			$summary = $album['title'];
+		}
+		return $summary ? mb_substr( $summary, 0, $maxLength ) : mb_substr( $this->yamlText, 0, $maxLength );
+	}
+
+	public function getNativeData(): string {
+		return $this->yamlText;
+	}
+
+	public function getSize(): int {
+		return strlen( $this->yamlText );
+	}
+
+	public function copy(): Content {
+		return new ReleaseDraftContent( $this->yamlText );
+	}
+
+	public function isCountable( $hasLinks = null ): bool {
+		return true;
+	}
+
+	public function serialize( $format = null ): string {
+		return $this->yamlText;
+	}
+}

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -1,0 +1,466 @@
+<?php
+/**
+ * Content handler for ReleaseDraft pages.
+ *
+ * Renders type-specific interactive forms:
+ * - Album drafts: track list with reorder, per-track metadata, album fields
+ * - All types: blockheight field, status display, finalize action
+ *
+ * The actual files live on delivery-kid's storage. This page holds
+ * the metadata and serves as the collaborative editing surface.
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+namespace MediaWiki\Extension\PickiPediaReleases;
+
+use Content;
+use MediaWiki\Content\ContentHandler;
+use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Content\ValidationParams;
+use MediaWiki\Html\Html;
+use MediaWiki\Parser\ParserOutput;
+use StatusValue;
+use Symfony\Component\Yaml\Yaml;
+
+class ReleaseDraftContentHandler extends ContentHandler {
+
+	public function __construct( $modelId = 'release-draft-yaml' ) {
+		parent::__construct( $modelId, [ CONTENT_FORMAT_TEXT ] );
+	}
+
+	public function serializeContent( Content $content, $format = null ): string {
+		if ( !$content instanceof ReleaseDraftContent ) {
+			throw new \InvalidArgumentException( 'Expected ReleaseDraftContent' );
+		}
+		return $content->getText();
+	}
+
+	public function unserializeContent( $text, $format = null ): ReleaseDraftContent {
+		return new ReleaseDraftContent( $text );
+	}
+
+	public function makeEmptyContent(): ReleaseDraftContent {
+		$yaml = Yaml::dump( [
+			'draft_id' => '',
+			'type' => 'album',
+			'status' => 'draft',
+			'blockheight' => null,
+			'album' => [
+				'title' => '',
+				'artist' => '',
+				'year' => '',
+				'description' => '',
+			],
+			'tracks' => [],
+			'result' => [
+				'cid' => null,
+				'gateway_url' => null,
+			],
+		], 4, 2 );
+		return new ReleaseDraftContent( $yaml );
+	}
+
+	public function validateSave(
+		Content $content,
+		ValidationParams $validationParams
+	): StatusValue {
+		if ( !$content instanceof ReleaseDraftContent ) {
+			return StatusValue::newFatal( 'invalid-content-data' );
+		}
+		return $content->validate();
+	}
+
+	protected function fillParserOutput(
+		Content $content,
+		ContentParseParams $cpoParams,
+		ParserOutput &$output
+	): void {
+		if ( !$content instanceof ReleaseDraftContent ) {
+			$output->setRawText( '<p>Invalid content type</p>' );
+			return;
+		}
+
+		$output->addModuleStyles( [ 'ext.pickipediaReleases.styles', 'ext.pickipediaReleases.upload.styles' ] );
+		$output->addModules( [ 'ext.pickipediaReleases.releaseDraft' ] );
+
+		$html = '';
+		$data = $content->getData();
+		$status = $content->getStatus();
+		$type = $content->getDraftType();
+
+		// Validation errors
+		$validation = $content->validate();
+		if ( !$validation->isOK() ) {
+			$html .= $this->renderValidationErrors( $validation );
+		}
+
+		// Status banner
+		$html .= $this->renderStatusBanner( $status, $data );
+
+		// If complete, show the result
+		if ( $status === 'complete' ) {
+			$html .= $this->renderResult( $data );
+		}
+
+		// Type-specific form
+		if ( $type === 'album' ) {
+			$html .= $this->renderAlbumForm( $data, $status );
+		} else {
+			$html .= $this->renderGenericForm( $data, $status );
+		}
+
+		// Blockheight field (all types)
+		$html .= $this->renderBlockheightField( $data );
+
+		// Action buttons
+		if ( $status === 'draft' ) {
+			$html .= $this->renderActions( $data );
+		}
+
+		// Raw YAML
+		$yamlText = trim( $content->getText() );
+		if ( !empty( $yamlText ) ) {
+			$html .= $this->renderRawYaml( $yamlText );
+		}
+
+		// Pass data to JS
+		$output->setJsConfigVar( 'wgReleaseDraftData', $data );
+
+		$output->setRawText( $html );
+
+		// Categories
+		$output->addCategory( 'Release_Drafts' );
+		if ( $status === 'complete' ) {
+			$output->addCategory( 'Completed_Drafts' );
+		}
+	}
+
+	private function renderStatusBanner( string $status, array $data ): string {
+		$classes = [
+			'draft' => 'rd-status-draft',
+			'finalizing' => 'rd-status-finalizing',
+			'complete' => 'rd-status-complete',
+		];
+		$labels = [
+			'draft' => 'Draft — not yet finalized',
+			'finalizing' => 'Finalizing — processing in progress',
+			'complete' => 'Complete — pinned to IPFS',
+		];
+
+		$class = $classes[$status] ?? 'rd-status-draft';
+		$label = $labels[$status] ?? 'Unknown status';
+
+		$type = $data['type'] ?? 'release';
+
+		return Html::rawElement( 'div', [ 'class' => "rd-status-banner $class" ],
+			Html::element( 'span', [ 'class' => 'rd-status-label' ], $label ) .
+			Html::element( 'span', [ 'class' => 'rd-status-type' ], ucfirst( $type ) . ' draft' )
+		);
+	}
+
+	private function renderResult( array $data ): string {
+		$result = $data['result'] ?? [];
+		if ( empty( $result['cid'] ) ) {
+			return '';
+		}
+
+		$cid = $result['cid'];
+		$gatewayUrl = $result['gateway_url'] ?? "https://ipfs.io/ipfs/{$cid}";
+		$releaseTitle = \MediaWiki\MediaWikiServices::getInstance()
+			->getTitleFactory()->makeTitle( NS_RELEASE, $cid );
+
+		$html = Html::openElement( 'div', [ 'class' => 'uc-result-card' ] );
+		$html .= Html::element( 'h4', [], 'Pinned to IPFS' );
+		$html .= Html::openElement( 'table', [ 'class' => 'wikitable' ] );
+
+		$html .= Html::openElement( 'tr' );
+		$html .= Html::element( 'th', [], 'CID' );
+		$html .= Html::element( 'td', [ 'class' => 'release-cid-cell' ], $cid );
+		$html .= Html::closeElement( 'tr' );
+
+		$html .= Html::openElement( 'tr' );
+		$html .= Html::element( 'th', [], 'Gateway' );
+		$html .= Html::rawElement( 'td', [],
+			Html::element( 'a', [ 'href' => $gatewayUrl, 'target' => '_blank' ], $gatewayUrl )
+		);
+		$html .= Html::closeElement( 'tr' );
+
+		if ( $releaseTitle ) {
+			$html .= Html::openElement( 'tr' );
+			$html .= Html::element( 'th', [], 'Release Page' );
+			$html .= Html::rawElement( 'td', [],
+				Html::element( 'a', [ 'href' => $releaseTitle->getLocalURL() ], $releaseTitle->getPrefixedText() )
+			);
+			$html .= Html::closeElement( 'tr' );
+		}
+
+		$html .= Html::closeElement( 'table' );
+		$html .= Html::closeElement( 'div' );
+
+		return $html;
+	}
+
+	private function renderAlbumForm( array $data, string $status ): string {
+		$album = $data['album'] ?? [];
+		$tracks = $data['tracks'] ?? [];
+		$disabled = $status !== 'draft' ? ' disabled' : '';
+
+		$html = Html::openElement( 'div', [ 'class' => 'rd-album-form', 'id' => 'rd-album-form' ] );
+		$html .= Html::element( 'h3', [], 'Album Info' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'uc-metadata-form' ] );
+
+		// Album title
+		$html .= $this->renderField( 'rd-album-title', 'Album Title',
+			$album['title'] ?? '', 'text', $disabled );
+
+		// Artist
+		$html .= $this->renderField( 'rd-artist', 'Artist',
+			$album['artist'] ?? '', 'text', $disabled );
+
+		// Year
+		$html .= $this->renderField( 'rd-year', 'Year',
+			$album['year'] ?? '', 'text', $disabled );
+
+		// Description
+		$html .= Html::openElement( 'div', [ 'class' => 'uc-field' ] );
+		$html .= Html::element( 'label', [ 'for' => 'rd-description' ], 'Description' );
+		$html .= Html::element( 'textarea', [
+			'id' => 'rd-description',
+			'class' => 'cdx-text-input__input',
+			'rows' => 3,
+			'placeholder' => 'Optional album description',
+			'disabled' => $status !== 'draft' ? true : false,
+		], $album['description'] ?? '' );
+		$html .= Html::closeElement( 'div' );
+
+		$html .= Html::closeElement( 'div' );
+
+		// Track list
+		$html .= Html::element( 'h3', [], 'Tracks' );
+		if ( $status === 'draft' ) {
+			$html .= Html::element( 'p', [ 'class' => 'uc-hint' ], 'Drag to reorder. Metadata field accepts key=value pairs (one per line) for Vorbis comments.' );
+		}
+
+		$html .= Html::openElement( 'div', [ 'id' => 'rd-track-list', 'class' => 'rd-track-list' ] );
+
+		foreach ( $tracks as $idx => $track ) {
+			$html .= $this->renderTrackRow( $idx, $track, $status );
+		}
+
+		$html .= Html::closeElement( 'div' );
+		$html .= Html::closeElement( 'div' );
+
+		return $html;
+	}
+
+	private function renderTrackRow( int $idx, array $track, string $status ): string {
+		$disabled = $status !== 'draft';
+		$num = $idx + 1;
+
+		$html = Html::openElement( 'div', [
+			'class' => 'rd-track-row',
+			'draggable' => $disabled ? 'false' : 'true',
+			'data-idx' => $idx,
+			'data-filename' => $track['filename'] ?? '',
+		] );
+
+		if ( !$disabled ) {
+			$html .= Html::element( 'span', [
+				'class' => 'ua-track-handle',
+				'title' => 'Drag to reorder',
+			], "\u{2630}" );
+		}
+
+		$html .= Html::element( 'span', [ 'class' => 'rd-track-num' ], (string)$num );
+
+		// Track info column
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-track-info' ] );
+
+		// Title input
+		$html .= Html::element( 'input', [
+			'type' => 'text',
+			'class' => 'rd-track-title cdx-text-input__input',
+			'value' => $track['title'] ?? '',
+			'data-filename' => $track['filename'] ?? '',
+			'disabled' => $disabled ? true : false,
+		] );
+
+		// File info
+		$meta = [];
+		if ( !empty( $track['format'] ) ) {
+			$meta[] = htmlspecialchars( $track['format'] );
+		}
+		if ( !empty( $track['duration'] ) ) {
+			$mins = floor( $track['duration'] / 60 );
+			$secs = floor( $track['duration'] % 60 );
+			$meta[] = $mins . ':' . str_pad( (string)$secs, 2, '0', STR_PAD_LEFT );
+		}
+		if ( !empty( $track['size_bytes'] ) ) {
+			$meta[] = $this->formatSize( (int)$track['size_bytes'] );
+		}
+		if ( !empty( $meta ) ) {
+			$html .= Html::rawElement( 'span', [ 'class' => 'rd-track-meta' ],
+				implode( ' &middot; ', $meta )
+			);
+		}
+
+		// Per-track metadata (freetext)
+		$html .= Html::element( 'textarea', [
+			'class' => 'rd-track-metadata',
+			'rows' => 2,
+			'placeholder' => 'COMPOSER=...' . "\n" . 'PERFORMER=...',
+			'disabled' => $disabled ? true : false,
+		], $track['metadata'] ?? '' );
+
+		$html .= Html::closeElement( 'div' );
+		$html .= Html::closeElement( 'div' );
+
+		return $html;
+	}
+
+	private function renderGenericForm( array $data, string $status ): string {
+		// Placeholder for non-album draft types
+		$html = Html::openElement( 'div', [ 'class' => 'rd-generic-form' ] );
+		$html .= Html::element( 'h3', [], 'Content Draft' );
+		$html .= Html::element( 'p', [], 'Draft type: ' . ( $data['type'] ?? 'unknown' ) );
+		$html .= Html::closeElement( 'div' );
+		return $html;
+	}
+
+	private function renderBlockheightField( array $data ): string {
+		$blockheight = $data['blockheight'] ?? '';
+
+		$html = Html::openElement( 'div', [ 'class' => 'rd-blockheight-section' ] );
+		$html .= Html::element( 'h3', [], 'Temporal Reference' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'uc-field' ] );
+		$html .= Html::element( 'label', [ 'for' => 'rd-blockheight' ], 'Ethereum Block Height' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-blockheight-row' ] );
+		$html .= Html::element( 'input', [
+			'type' => 'text',
+			'id' => 'rd-blockheight',
+			'class' => 'cdx-text-input__input rd-blockheight-input',
+			'value' => $blockheight,
+			'placeholder' => 'e.g. 24631327',
+		] );
+		$html .= Html::element( 'button', [
+			'type' => 'button',
+			'id' => 'rd-blockheight-now',
+			'class' => 'cdx-button',
+		], 'Current Block' );
+		$html .= Html::element( 'span', [ 'id' => 'rd-blockheight-date', 'class' => 'rd-blockheight-date' ], '' );
+		$html .= Html::closeElement( 'div' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-date-converter' ] );
+		$html .= Html::element( 'label', [ 'for' => 'rd-date-input' ], 'Or pick a date:' );
+		$html .= Html::element( 'input', [
+			'type' => 'date',
+			'id' => 'rd-date-input',
+			'class' => 'cdx-text-input__input rd-date-input',
+		] );
+		$html .= Html::closeElement( 'div' );
+
+		$html .= Html::closeElement( 'div' );
+		$html .= Html::closeElement( 'div' );
+
+		return $html;
+	}
+
+	private function renderActions( array $data ): string {
+		$draftId = $data['draft_id'] ?? '';
+
+		$html = Html::openElement( 'div', [ 'class' => 'rd-actions', 'id' => 'rd-actions' ] );
+
+		$html .= Html::element( 'button', [
+			'type' => 'button',
+			'id' => 'rd-save-btn',
+			'class' => 'cdx-button cdx-button--action-progressive',
+		], 'Save Draft' );
+
+		$html .= Html::element( 'button', [
+			'type' => 'button',
+			'id' => 'rd-finalize-btn',
+			'class' => 'cdx-button cdx-button--action-progressive cdx-button--weight-primary',
+		], 'Finalize & Pin to IPFS' );
+
+		$html .= Html::openElement( 'div', [
+			'id' => 'rd-finalize-progress',
+			'class' => 'uc-step',
+			'style' => 'display:none',
+		] );
+		$html .= Html::rawElement( 'div', [
+			'id' => 'rd-progress-bar',
+			'class' => 'uc-progress-bar',
+		], Html::element( 'div', [ 'class' => 'uc-progress-fill' ] ) );
+		$html .= Html::element( 'div', [ 'id' => 'rd-progress-status', 'class' => 'uc-status' ] );
+		$html .= Html::closeElement( 'div' );
+
+		$html .= Html::closeElement( 'div' );
+
+		return $html;
+	}
+
+	private function renderField( string $id, string $label, string $value, string $type, string $disabled ): string {
+		$html = Html::openElement( 'div', [ 'class' => 'uc-field' ] );
+		$html .= Html::element( 'label', [ 'for' => $id ], $label );
+		$attrs = [
+			'type' => $type,
+			'id' => $id,
+			'class' => 'cdx-text-input__input',
+			'value' => $value,
+		];
+		if ( $disabled ) {
+			$attrs['disabled'] = true;
+		}
+		$html .= Html::element( 'input', $attrs );
+		$html .= Html::closeElement( 'div' );
+		return $html;
+	}
+
+	private function formatSize( int $bytes ): string {
+		$units = [ 'B', 'KB', 'MB', 'GB' ];
+		$size = (float)$bytes;
+		$i = 0;
+		while ( $size >= 1024 && $i < count( $units ) - 1 ) {
+			$size /= 1024;
+			$i++;
+		}
+		return round( $size, 1 ) . ' ' . $units[$i];
+	}
+
+	private function renderValidationErrors( StatusValue $status ): string {
+		$errors = $status->getMessages( 'error' );
+		$errorHtml = Html::element( 'strong', [], 'Validation Errors:' );
+		$errorList = Html::openElement( 'ul' );
+		foreach ( $errors as $error ) {
+			$errorList .= Html::element( 'li', [], wfMessage( $error )->text() );
+		}
+		$errorList .= Html::closeElement( 'ul' );
+		return Html::rawElement( 'div', [ 'class' => 'release-validation-error' ],
+			$errorHtml . $errorList
+		);
+	}
+
+	private function renderRawYaml( string $yaml ): string {
+		return Html::rawElement( 'details', [ 'class' => 'release-raw-yaml' ],
+			Html::element( 'summary', [], 'Raw YAML' ) .
+			Html::element( 'pre', [], $yaml )
+		);
+	}
+
+	public function supportsDirectEditing(): bool {
+		return true;
+	}
+
+	public function supportsDirectApiEditing(): bool {
+		return true;
+	}
+
+	public function getActionOverrides(): array {
+		return [];
+	}
+}

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -389,14 +389,32 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 
 		$html .= Html::openElement( 'div', [
 			'id' => 'rd-finalize-progress',
-			'class' => 'uc-step',
+			'class' => 'rd-finalize-progress',
 			'style' => 'display:none',
 		] );
+
+		// Stage indicators
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-stages', 'id' => 'rd-stages' ] );
+		$stages = [ 'preparing' => 'Preparing', 'transcoding' => 'Transcoding', 'tagging' => 'Tagging', 'pinning' => 'Pinning', 'complete' => 'Complete' ];
+		foreach ( $stages as $key => $label ) {
+			$html .= Html::element( 'span', [
+				'class' => 'rd-stage',
+				'data-stage' => $key,
+			], $label );
+		}
+		$html .= Html::closeElement( 'div' );
+
+		// Progress bar
 		$html .= Html::rawElement( 'div', [
 			'id' => 'rd-progress-bar',
 			'class' => 'uc-progress-bar',
 		], Html::element( 'div', [ 'class' => 'uc-progress-fill' ] ) );
-		$html .= Html::element( 'div', [ 'id' => 'rd-progress-status', 'class' => 'uc-status' ] );
+
+		// Current activity log
+		$html .= Html::element( 'div', [ 'id' => 'rd-progress-status', 'class' => 'rd-progress-status' ] );
+		$html .= Html::openElement( 'div', [ 'id' => 'rd-progress-log', 'class' => 'rd-progress-log' ] );
+		$html .= Html::closeElement( 'div' );
+
 		$html .= Html::closeElement( 'div' );
 
 		$html .= Html::closeElement( 'div' );

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -16,15 +16,15 @@
 namespace MediaWiki\Extension\PickiPediaReleases;
 
 use Content;
-use MediaWiki\Content\ContentHandler;
 use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Content\TextContentHandler;
 use MediaWiki\Content\ValidationParams;
 use MediaWiki\Html\Html;
 use MediaWiki\Parser\ParserOutput;
 use StatusValue;
 use Symfony\Component\Yaml\Yaml;
 
-class ReleaseDraftContentHandler extends ContentHandler {
+class ReleaseDraftContentHandler extends TextContentHandler {
 
 	public function __construct( $modelId = 'release-draft-yaml' ) {
 		parent::__construct( $modelId, [ CONTENT_FORMAT_TEXT ] );
@@ -50,7 +50,7 @@ class ReleaseDraftContentHandler extends ContentHandler {
 			'album' => [
 				'title' => '',
 				'artist' => '',
-				'year' => '',
+				'version' => '',
 				'description' => '',
 			],
 			'tracks' => [],
@@ -220,9 +220,9 @@ class ReleaseDraftContentHandler extends ContentHandler {
 		$html .= $this->renderField( 'rd-artist', 'Artist',
 			$album['artist'] ?? '', 'text', $disabled );
 
-		// Year
-		$html .= $this->renderField( 'rd-year', 'Year',
-			$album['year'] ?? '', 'text', $disabled );
+		// Version
+		$html .= $this->renderField( 'rd-version', 'Version',
+			$album['version'] ?? '', 'text', $disabled );
 
 		// Description
 		$html .= Html::openElement( 'div', [ 'class' => 'uc-field' ] );

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -395,7 +395,7 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 
 		// Stage indicators
 		$html .= Html::openElement( 'div', [ 'class' => 'rd-stages', 'id' => 'rd-stages' ] );
-		$stages = [ 'preparing' => 'Preparing', 'transcoding' => 'Transcoding', 'tagging' => 'Tagging', 'pinning' => 'Pinning', 'complete' => 'Complete' ];
+		$stages = [ 'preparing' => 'Preparing', 'transcoding' => 'Transcoding', 'tagging' => 'Tagging', 'pinning' => 'Pinning', 'torrenting' => 'Torrenting', 'complete' => 'Complete' ];
 		foreach ( $stages as $key => $label ) {
 			$html .= Html::element( 'span', [
 				'class' => 'rd-stage',

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -395,7 +395,7 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 
 		// Stage indicators
 		$html .= Html::openElement( 'div', [ 'class' => 'rd-stages', 'id' => 'rd-stages' ] );
-		$stages = [ 'preparing' => 'Preparing', 'transcoding' => 'Transcoding', 'tagging' => 'Tagging', 'pinning' => 'Pinning', 'torrenting' => 'Torrenting', 'complete' => 'Complete' ];
+		$stages = [ 'preparing' => 'Preparing', 'transcoding' => 'Transcoding', 'tagging' => 'Tagging', 'pinning' => 'Pinning', 'complete' => 'Complete' ];
 		foreach ( $stages as $key => $label ) {
 			$html .= Html::element( 'span', [
 				'class' => 'rd-stage',

--- a/extensions/PickiPediaReleases/src/SpecialReleases.php
+++ b/extensions/PickiPediaReleases/src/SpecialReleases.php
@@ -26,13 +26,34 @@ class SpecialReleases extends SpecialPage {
 		$out = $this->getOutput();
 		$out->addModuleStyles( [ 'ext.pickipediaReleases.styles' ] );
 
+		// Editable header: MediaWiki:special-releases-header
+		$this->addWikitextMessage( 'special-releases-header' );
+
 		$releases = $this->getReleases();
 
 		$out->addHTML( Html::element( 'p', [],
 			count( $releases ) . ' releases in the catalog.'
 		) );
 
+		// Editable mid-section: MediaWiki:special-releases-mid
+		$this->addWikitextMessage( 'special-releases-mid' );
+
 		$out->addHTML( $this->renderTable( $releases ) );
+
+		// Editable footer: MediaWiki:special-releases-footer
+		$this->addWikitextMessage( 'special-releases-footer' );
+	}
+
+	/**
+	 * Parse and output a MediaWiki message as wikitext, if it exists and is non-empty.
+	 *
+	 * @param string $msgKey
+	 */
+	private function addWikitextMessage( string $msgKey ): void {
+		$msg = $this->msg( $msgKey );
+		if ( !$msg->isDisabled() ) {
+			$this->getOutput()->addWikiTextAsInterface( $msg->plain() );
+		}
 	}
 
 	/**

--- a/extensions/PickiPediaReleases/src/SpecialUploadAlbum.php
+++ b/extensions/PickiPediaReleases/src/SpecialUploadAlbum.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Special page for uploading albums directly to delivery-kid.
+ *
+ * Wiki login is the auth layer. PHP generates a short-lived HMAC token.
+ * JavaScript uploads files directly to delivery-kid — no bytes pass through PHP.
+ *
+ * Uses the /draft-album multi-step workflow:
+ * 1. Upload audio files + cover art → delivery-kid analyzes them
+ * 2. Review metadata, reorder tracks, edit titles
+ * 3. Finalize → transcode, tag, pin to IPFS
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+namespace MediaWiki\Extension\PickiPediaReleases;
+
+use MediaWiki\Html\Html;
+use MediaWiki\SpecialPage\SpecialPage;
+
+class SpecialUploadAlbum extends SpecialPage {
+
+	public function __construct() {
+		parent::__construct( 'UploadAlbum', 'upload-to-delivery-kid' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( $par ): void {
+		$this->setHeaders();
+		$this->checkPermissions();
+		$out = $this->getOutput();
+		$user = $this->getUser();
+
+		$out->addModuleStyles( [ 'ext.pickipediaReleases.upload.styles' ] );
+		$out->addModules( [ 'ext.pickipediaReleases.uploadAlbum' ] );
+
+		// Generate HMAC upload token
+		$apiKey = $this->getConfig()->get( 'DeliveryKidApiKey' );
+		$apiUrl = $this->getConfig()->get( 'DeliveryKidUrl' );
+		$username = $user->getName();
+		$timestamp = (int)( microtime( true ) * 1000 );
+		$token = hash_hmac( 'sha256', "upload:{$username}:{$timestamp}", $apiKey );
+
+		// Pass config to JS — token is short-lived, not a persistent secret
+		$out->addJsConfigVars( [
+			'wgDeliveryKidUrl' => $apiUrl,
+			'wgUploadToken' => $token,
+			'wgUploadUser' => $username,
+			'wgUploadTimestamp' => $timestamp,
+		] );
+
+		// Editable intro text
+		$this->addWikitextMessage( 'special-uploadalbum-header' );
+
+		$out->addHTML( $this->renderPageStructure() );
+	}
+
+	/**
+	 * Render the HTML skeleton. JS handles all interactivity.
+	 */
+	private function renderPageStructure(): string {
+		$html = '';
+
+		// Step 1: File upload
+		$html .= '<div id="ua-step-upload" class="uc-step uc-step-active">';
+		$html .= '<h3>Upload Album Files</h3>';
+		$html .= '<p>Upload audio tracks and optional cover art. Supported formats: FLAC, WAV, OGG, MP3, M4A.</p>';
+		$html .= '<div id="ua-dropzone" class="uc-dropzone">';
+		$html .= '<p>Drag audio files here or click to select</p>';
+		$html .= '<p class="uc-hint">FLAC &amp; WAV will be archived and transcoded to OGG</p>';
+		$html .= '<input type="file" id="ua-file-input" multiple accept=".flac,.wav,.ogg,.mp3,.m4a,.jpg,.jpeg,.png,.webp" style="display:none">';
+		$html .= '</div>';
+		$html .= '<div id="ua-file-list" class="uc-file-list"></div>';
+		$html .= '<button id="ua-upload-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary" disabled>Upload &amp; Analyze</button>';
+		$html .= '<div id="ua-upload-progress" class="uc-progress-bar" style="display:none"><div class="uc-progress-fill"></div></div>';
+		$html .= '<div id="ua-upload-status" class="uc-status"></div>';
+		$html .= '</div>';
+
+		// Step 2: Review tracks and metadata
+		$html .= '<div id="ua-step-review" class="uc-step">';
+		$html .= '<h3>Review &amp; Organize</h3>';
+		$html .= '<div id="ua-draft-info" class="uc-draft-info"></div>';
+
+		// Album metadata
+		$html .= '<div class="uc-metadata-form">';
+		$html .= '<div class="uc-field"><label for="ua-album-title">Album Title</label>';
+		$html .= '<input type="text" id="ua-album-title" class="cdx-text-input__input" placeholder="Album title" required></div>';
+		$html .= '<div class="uc-field"><label for="ua-artist">Artist</label>';
+		$html .= '<input type="text" id="ua-artist" class="cdx-text-input__input" placeholder="Artist name" required></div>';
+		$html .= '<div class="uc-field"><label for="ua-year">Year</label>';
+		$html .= '<input type="text" id="ua-year" class="cdx-text-input__input" placeholder="e.g. 2026"></div>';
+		$html .= '<div class="uc-field"><label for="ua-description">Description</label>';
+		$html .= '<textarea id="ua-description" class="cdx-text-input__input" rows="3" placeholder="Optional album description"></textarea></div>';
+		$html .= '</div>';
+
+		// Track list (populated by JS)
+		$html .= '<h4>Track List <span class="uc-hint">(drag to reorder)</span></h4>';
+		$html .= '<div id="ua-track-list" class="ua-track-list"></div>';
+
+		$html .= '<div class="uc-button-row">';
+		$html .= '<button id="ua-finalize-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">Finalize &amp; Pin</button>';
+		$html .= '<button id="ua-delete-draft-btn" class="cdx-button cdx-button--action-destructive">Delete Draft</button>';
+		$html .= '</div>';
+		$html .= '</div>';
+
+		// Step 3: Progress and result
+		$html .= '<div id="ua-step-progress" class="uc-step">';
+		$html .= '<h3>Processing Album</h3>';
+		$html .= '<div id="ua-progress-bar" class="uc-progress-bar"><div class="uc-progress-fill"></div></div>';
+		$html .= '<div id="ua-progress-status" class="uc-status"></div>';
+		$html .= '<div id="ua-result" class="uc-result"></div>';
+		$html .= '</div>';
+
+		return $html;
+	}
+
+	/**
+	 * Parse and output a MediaWiki message as wikitext, if it exists and is non-empty.
+	 */
+	private function addWikitextMessage( string $msgKey ): void {
+		$msg = $this->msg( $msgKey );
+		if ( !$msg->isDisabled() ) {
+			$this->getOutput()->addWikiTextAsInterface( $msg->plain() );
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getGroupName(): string {
+		return 'media';
+	}
+}

--- a/extensions/PickiPediaReleases/src/SpecialUploadAlbum.php
+++ b/extensions/PickiPediaReleases/src/SpecialUploadAlbum.php
@@ -59,15 +59,15 @@ class SpecialUploadAlbum extends SpecialPage {
 	}
 
 	/**
-	 * Render the HTML skeleton. JS handles all interactivity.
+	 * Render the HTML skeleton. JS handles upload, then creates a ReleaseDraft page.
 	 */
 	private function renderPageStructure(): string {
 		$html = '';
 
-		// Step 1: File upload
 		$html .= '<div id="ua-step-upload" class="uc-step uc-step-active">';
 		$html .= '<h3>Upload Album Files</h3>';
 		$html .= '<p>Upload audio tracks and optional cover art. Supported formats: FLAC, WAV, OGG, MP3, M4A.</p>';
+		$html .= '<p>After upload, a draft page will be created where you can edit metadata, reorder tracks, and finalize.</p>';
 		$html .= '<div id="ua-dropzone" class="uc-dropzone">';
 		$html .= '<p>Drag audio files here or click to select</p>';
 		$html .= '<p class="uc-hint">FLAC &amp; WAV will be archived and transcoded to OGG</p>';
@@ -77,41 +77,6 @@ class SpecialUploadAlbum extends SpecialPage {
 		$html .= '<button id="ua-upload-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary" disabled>Upload &amp; Analyze</button>';
 		$html .= '<div id="ua-upload-progress" class="uc-progress-bar" style="display:none"><div class="uc-progress-fill"></div></div>';
 		$html .= '<div id="ua-upload-status" class="uc-status"></div>';
-		$html .= '</div>';
-
-		// Step 2: Review tracks and metadata
-		$html .= '<div id="ua-step-review" class="uc-step">';
-		$html .= '<h3>Review &amp; Organize</h3>';
-		$html .= '<div id="ua-draft-info" class="uc-draft-info"></div>';
-
-		// Album metadata
-		$html .= '<div class="uc-metadata-form">';
-		$html .= '<div class="uc-field"><label for="ua-album-title">Album Title</label>';
-		$html .= '<input type="text" id="ua-album-title" class="cdx-text-input__input" placeholder="Album title" required></div>';
-		$html .= '<div class="uc-field"><label for="ua-artist">Artist</label>';
-		$html .= '<input type="text" id="ua-artist" class="cdx-text-input__input" placeholder="Artist name" required></div>';
-		$html .= '<div class="uc-field"><label for="ua-year">Year</label>';
-		$html .= '<input type="text" id="ua-year" class="cdx-text-input__input" placeholder="e.g. 2026"></div>';
-		$html .= '<div class="uc-field"><label for="ua-description">Description</label>';
-		$html .= '<textarea id="ua-description" class="cdx-text-input__input" rows="3" placeholder="Optional album description"></textarea></div>';
-		$html .= '</div>';
-
-		// Track list (populated by JS)
-		$html .= '<h4>Track List <span class="uc-hint">(drag to reorder)</span></h4>';
-		$html .= '<div id="ua-track-list" class="ua-track-list"></div>';
-
-		$html .= '<div class="uc-button-row">';
-		$html .= '<button id="ua-finalize-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">Finalize &amp; Pin</button>';
-		$html .= '<button id="ua-delete-draft-btn" class="cdx-button cdx-button--action-destructive">Delete Draft</button>';
-		$html .= '</div>';
-		$html .= '</div>';
-
-		// Step 3: Progress and result
-		$html .= '<div id="ua-step-progress" class="uc-step">';
-		$html .= '<h3>Processing Album</h3>';
-		$html .= '<div id="ua-progress-bar" class="uc-progress-bar"><div class="uc-progress-fill"></div></div>';
-		$html .= '<div id="ua-progress-status" class="uc-status"></div>';
-		$html .= '<div id="ua-result" class="uc-result"></div>';
 		$html .= '</div>';
 
 		return $html;

--- a/extensions/PickiPediaReleases/src/SpecialUploadContent.php
+++ b/extensions/PickiPediaReleases/src/SpecialUploadContent.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Special page for uploading content to delivery-kid pinning service.
+ *
+ * Provides a multi-step workflow:
+ * 1. Connect wallet (MetaMask)
+ * 2. Upload files -> creates draft on delivery-kid
+ * 3. Review analysis, edit metadata
+ * 4. Finalize -> transcode (if needed) + pin to IPFS
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+namespace MediaWiki\Extension\PickiPediaReleases;
+
+use MediaWiki\SpecialPage\SpecialPage;
+
+class SpecialUploadContent extends SpecialPage {
+
+	public function __construct() {
+		parent::__construct( 'UploadContent', 'upload' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( $par ): void {
+		$this->setHeaders();
+		$this->checkPermissions();
+		$out = $this->getOutput();
+
+		$out->addModuleStyles( [ 'ext.pickipediaReleases.upload.styles' ] );
+		$out->addModules( [ 'ext.pickipediaReleases.upload' ] );
+
+		// Pass config to JS
+		$out->addJsConfigVars( [
+			'wgDeliveryKidUrl' => $this->getConfig()->get( 'DeliveryKidUrl' ),
+		] );
+
+		// Editable intro text
+		$this->addWikitextMessage( 'special-uploadcontent-header' );
+
+		$out->addHTML( $this->renderPageStructure() );
+	}
+
+	/**
+	 * Render the HTML skeleton for the upload workflow.
+	 * JS handles all interactivity.
+	 */
+	private function renderPageStructure(): string {
+		$html = '';
+
+		// Step 1: Wallet connection
+		$html .= '<div id="uc-step-wallet" class="uc-step uc-step-active">';
+		$html .= '<h3>Step 1: Connect Wallet</h3>';
+		$html .= '<p>Connect your Ethereum wallet to authenticate with the pinning service.</p>';
+		$html .= '<button id="uc-connect-wallet" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">Connect Wallet</button>';
+		$html .= '<div id="uc-wallet-status" class="uc-status"></div>';
+		$html .= '</div>';
+
+		// Step 2: File upload
+		$html .= '<div id="uc-step-upload" class="uc-step">';
+		$html .= '<h3>Step 2: Upload Files</h3>';
+		$html .= '<div id="uc-dropzone" class="uc-dropzone">';
+		$html .= '<p>Drag files here or click to select</p>';
+		$html .= '<p class="uc-hint">Audio (FLAC, WAV, MP3, OGG, M4A, AAC, OPUS), ';
+		$html .= 'Video (MP4, WebM, MOV, MKV, AVI), ';
+		$html .= 'Images (JPG, PNG, WebP, GIF)</p>';
+		$html .= '<input type="file" id="uc-file-input" multiple style="display:none">';
+		$html .= '</div>';
+		$html .= '<div id="uc-file-list" class="uc-file-list"></div>';
+		$html .= '<button id="uc-upload-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary" disabled>Upload Files</button>';
+		$html .= '<div id="uc-upload-status" class="uc-status"></div>';
+		$html .= '</div>';
+
+		// Step 3: Review and metadata
+		$html .= '<div id="uc-step-review" class="uc-step">';
+		$html .= '<h3>Step 3: Review &amp; Metadata</h3>';
+		$html .= '<div id="uc-draft-info" class="uc-draft-info"></div>';
+		$html .= '<div class="uc-metadata-form">';
+		$html .= '<div class="uc-field"><label for="uc-title">Title</label>';
+		$html .= '<input type="text" id="uc-title" class="cdx-text-input__input" placeholder="Content title"></div>';
+		$html .= '<div class="uc-field"><label for="uc-description">Description</label>';
+		$html .= '<textarea id="uc-description" class="cdx-text-input__input" rows="3" placeholder="Optional description"></textarea></div>';
+		$html .= '<div class="uc-field"><label for="uc-file-type">File type override</label>';
+		$html .= '<input type="text" id="uc-file-type" class="cdx-text-input__input" placeholder="e.g., video/webm (leave blank for auto)"></div>';
+		$html .= '<div class="uc-field"><label for="uc-subsequent-to">Subsequent to (CID)</label>';
+		$html .= '<input type="text" id="uc-subsequent-to" class="cdx-text-input__input" placeholder="CID this content supersedes"></div>';
+		$html .= '<div class="uc-field uc-checkbox-field">';
+		$html .= '<label><input type="checkbox" id="uc-transcode-hls"> Transcode video to HLS before pinning</label></div>';
+		$html .= '</div>';
+		$html .= '<button id="uc-finalize-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">Finalize &amp; Pin</button>';
+		$html .= '<button id="uc-delete-draft-btn" class="cdx-button cdx-button--action-destructive">Delete Draft</button>';
+		$html .= '</div>';
+
+		// Step 4: Progress and result
+		$html .= '<div id="uc-step-progress" class="uc-step">';
+		$html .= '<h3>Step 4: Pinning</h3>';
+		$html .= '<div id="uc-progress-bar" class="uc-progress-bar"><div class="uc-progress-fill"></div></div>';
+		$html .= '<div id="uc-progress-status" class="uc-status"></div>';
+		$html .= '<div id="uc-result" class="uc-result"></div>';
+		$html .= '</div>';
+
+		return $html;
+	}
+
+	/**
+	 * Parse and output a MediaWiki message as wikitext, if it exists and is non-empty.
+	 */
+	private function addWikitextMessage( string $msgKey ): void {
+		$msg = $this->msg( $msgKey );
+		if ( !$msg->isDisabled() ) {
+			$this->getOutput()->addWikiTextAsInterface( $msg->plain() );
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getGroupName(): string {
+		return 'media';
+	}
+}

--- a/extensions/PickiPediaReleases/src/SpecialUploadContent.php
+++ b/extensions/PickiPediaReleases/src/SpecialUploadContent.php
@@ -1,13 +1,15 @@
 <?php
 /**
- * Special page for uploading content to delivery-kid pinning service.
+ * Special page for uploading content directly to delivery-kid.
  *
- * Wiki login is the auth layer. PHP proxies uploads to delivery-kid
- * using a shared API key — no wallet connection needed.
+ * Wiki login is the auth layer. PHP generates a short-lived HMAC token.
+ * JavaScript uploads files directly to delivery-kid — no bytes pass through PHP.
  *
- * Two-step flow:
- * 1. Upload files → shows analysis/preview
- * 2. Review metadata, finalize → pins to IPFS, shows result
+ * Flow:
+ * 1. User logs in to wiki (must have 'upload-to-delivery-kid' right)
+ * 2. PHP generates HMAC upload token from shared API key
+ * 3. JS uploads directly to delivery-kid with the token
+ * 4. JS handles the review/finalize steps
  *
  * @file
  * @ingroup Extensions
@@ -21,7 +23,7 @@ use MediaWiki\SpecialPage\SpecialPage;
 class SpecialUploadContent extends SpecialPage {
 
 	public function __construct() {
-		parent::__construct( 'UploadContent', 'upload' );
+		parent::__construct( 'UploadContent', 'upload-to-delivery-kid' );
 	}
 
 	/**
@@ -31,524 +33,84 @@ class SpecialUploadContent extends SpecialPage {
 		$this->setHeaders();
 		$this->checkPermissions();
 		$out = $this->getOutput();
-		$request = $this->getRequest();
+		$user = $this->getUser();
 
 		$out->addModuleStyles( [ 'ext.pickipediaReleases.upload.styles' ] );
+		$out->addModules( [ 'ext.pickipediaReleases.upload' ] );
+
+		// Generate HMAC upload token
+		$apiKey = $this->getConfig()->get( 'DeliveryKidApiKey' );
+		$apiUrl = $this->getConfig()->get( 'DeliveryKidUrl' );
+		$username = $user->getName();
+		$timestamp = (int)( microtime( true ) * 1000 );
+		$token = hash_hmac( 'sha256', "upload:{$username}:{$timestamp}", $apiKey );
+
+		// Pass config to JS — token is short-lived, not a persistent secret
+		$out->addJsConfigVars( [
+			'wgDeliveryKidUrl' => $apiUrl,
+			'wgUploadToken' => $token,
+			'wgUploadUser' => $username,
+			'wgUploadTimestamp' => $timestamp,
+		] );
 
 		// Editable intro text
 		$this->addWikitextMessage( 'special-uploadcontent-header' );
 
-		$action = $request->getVal( 'action', '' );
-
-		if ( $action === 'finalize' ) {
-			$this->handleFinalize( $request );
-		} elseif ( $action === 'delete' ) {
-			$this->handleDelete( $request );
-		} elseif ( $action === 'upload' && $request->wasPosted() ) {
-			$this->handleUpload( $request );
-		} elseif ( $request->getVal( 'draft_id' ) ) {
-			$this->showReviewStep( $request->getVal( 'draft_id' ) );
-		} else {
-			$this->showUploadForm();
-		}
+		$out->addHTML( $this->renderPageStructure() );
 	}
 
 	/**
-	 * Step 1: Show the file upload form.
+	 * Render the HTML skeleton. JS handles all interactivity.
 	 */
-	private function showUploadForm(): void {
-		$out = $this->getOutput();
-
-		$out->addHTML( '<div class="uc-step uc-step-active">' );
-		$out->addHTML( Html::element( 'h3', [], 'Upload Files' ) );
-		$out->addHTML( '<p>Select files to upload for review before pinning to IPFS.</p>' );
-		$out->addHTML( '<p class="uc-hint">Audio (FLAC, WAV, MP3, OGG), ' .
-			'Video (MP4, WebM, MOV, MKV), Images (JPG, PNG, WebP, GIF)</p>' );
-
-		$out->addHTML( Html::openElement( 'form', [
-			'method' => 'post',
-			'enctype' => 'multipart/form-data',
-			'action' => $this->getPageTitle()->getLocalURL( [ 'action' => 'upload' ] ),
-		] ) );
-
-		$out->addHTML( Html::input( 'wpEditToken', $this->getUser()->getEditToken(), 'hidden' ) );
-
-		$out->addHTML( '<div class="uc-field">' );
-		$out->addHTML( Html::element( 'label', [ 'for' => 'uc-files' ], 'Files' ) );
-		$out->addHTML( Html::input( 'files[]', '', 'file', [
-			'id' => 'uc-files',
-			'multiple' => true,
-			'accept' => '.flac,.wav,.mp3,.ogg,.m4a,.aac,.opus,.mp4,.webm,.mov,.mkv,.avi,.ts,.jpg,.jpeg,.png,.webp,.gif,.svg',
-		] ) );
-		$out->addHTML( '</div>' );
-
-		$out->addHTML( Html::submitButton( 'Upload & Analyze', [
-			'class' => 'cdx-button cdx-button--action-progressive cdx-button--weight-primary',
-		] ) );
-
-		$out->addHTML( Html::closeElement( 'form' ) );
-		$out->addHTML( '</div>' );
-	}
-
-	/**
-	 * Handle file upload POST — send files to delivery-kid, show review form.
-	 */
-	private function handleUpload( \MediaWiki\Request\WebRequest $request ): void {
-		$out = $this->getOutput();
-		$user = $this->getUser();
-
-		if ( !$user->matchEditToken( $request->getVal( 'wpEditToken' ) ) ) {
-			$out->addHTML( '<div class="uc-status uc-status-error">Invalid session token. Please try again.</div>' );
-			$this->showUploadForm();
-			return;
-		}
-
-		$uploadedFiles = $request->getUploadDir() !== null ? $_FILES['files'] ?? null : null;
-		// Fallback: PHP populates $_FILES directly
-		if ( $uploadedFiles === null ) {
-			$uploadedFiles = $_FILES['files'] ?? null;
-		}
-
-		if ( !$uploadedFiles || empty( $uploadedFiles['name'][0] ) ) {
-			$out->addHTML( '<div class="uc-status uc-status-error">No files selected.</div>' );
-			$this->showUploadForm();
-			return;
-		}
-
-		$apiUrl = $this->getConfig()->get( 'DeliveryKidUrl' );
-		$apiKey = $this->getConfig()->get( 'DeliveryKidApiKey' );
-
-		// Build multipart POST to delivery-kid
-		$curl = curl_init( $apiUrl . '/draft-content' );
-		$postFields = [];
-
-		// PHP receives multiple files as arrays of names/tmp_names/etc.
-		$fileCount = count( $uploadedFiles['name'] );
-		for ( $i = 0; $i < $fileCount; $i++ ) {
-			if ( $uploadedFiles['error'][$i] !== UPLOAD_ERR_OK ) {
-				continue;
-			}
-			$postFields["files[$i]"] = new \CURLFile(
-				$uploadedFiles['tmp_name'][$i],
-				$uploadedFiles['type'][$i],
-				$uploadedFiles['name'][$i]
-			);
-		}
-
-		if ( empty( $postFields ) ) {
-			$out->addHTML( '<div class="uc-status uc-status-error">No valid files to upload.</div>' );
-			$this->showUploadForm();
-			return;
-		}
-
-		curl_setopt_array( $curl, [
-			CURLOPT_POST => true,
-			CURLOPT_POSTFIELDS => $postFields,
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_HTTPHEADER => [
-				'X-API-Key: ' . $apiKey,
-				'X-Uploaded-By: wiki:' . $user->getName(),
-			],
-			CURLOPT_TIMEOUT => 120,
-		] );
-
-		$response = curl_exec( $curl );
-		$httpCode = curl_getinfo( $curl, CURLINFO_HTTP_CODE );
-		$curlError = curl_error( $curl );
-		curl_close( $curl );
-
-		if ( $curlError ) {
-			$out->addHTML( '<div class="uc-status uc-status-error">Connection error: ' .
-				htmlspecialchars( $curlError ) . '</div>' );
-			$this->showUploadForm();
-			return;
-		}
-
-		$data = json_decode( $response, true );
-
-		if ( $httpCode !== 200 || !$data ) {
-			$detail = $data['detail'] ?? $response;
-			$out->addHTML( '<div class="uc-status uc-status-error">Upload failed (' .
-				$httpCode . '): ' . htmlspecialchars( $detail ) . '</div>' );
-			$this->showUploadForm();
-			return;
-		}
-
-		$this->showReviewForm( $data );
-	}
-
-	/**
-	 * Step 2: Show review form with file analysis and metadata fields.
-	 */
-	private function showReviewForm( array $draft ): void {
-		$out = $this->getOutput();
-
-		$out->addHTML( '<div class="uc-step uc-step-active">' );
-		$out->addHTML( Html::element( 'h3', [], 'Review & Finalize' ) );
-
-		// File analysis table
-		$out->addHTML( '<table class="wikitable">' );
-		$out->addHTML( '<tr><th>File</th><th>Type</th><th>Format</th><th>Duration</th><th>Size</th></tr>' );
-
-		$hasVideo = false;
-		foreach ( $draft['files'] as $f ) {
-			$out->addHTML( '<tr>' );
-			$out->addHTML( Html::element( 'td', [], $f['original_filename'] ) );
-			$out->addHTML( Html::element( 'td', [], $f['media_type'] ) );
-			$out->addHTML( Html::element( 'td', [], $f['format'] ) );
-			$duration = '';
-			if ( !empty( $f['duration_seconds'] ) ) {
-				$m = floor( $f['duration_seconds'] / 60 );
-				$s = floor( $f['duration_seconds'] ) % 60;
-				$duration = sprintf( '%d:%02d', $m, $s );
-			}
-			$out->addHTML( Html::element( 'td', [], $duration ) );
-			$out->addHTML( Html::element( 'td', [], $this->formatFileSize( $f['size_bytes'] ) ) );
-			$out->addHTML( '</tr>' );
-
-			if ( !empty( $f['width'] ) && !empty( $f['height'] ) ) {
-				$details = $f['width'] . 'x' . $f['height'];
-				if ( !empty( $f['video_codec'] ) ) {
-					$details .= ' · ' . $f['video_codec'];
-				}
-				if ( !empty( $f['audio_codec'] ) ) {
-					$details .= ' · ' . $f['audio_codec'];
-				}
-				$out->addHTML( '<tr><td></td><td colspan="4">' .
-					htmlspecialchars( $details ) . '</td></tr>' );
-			}
-
-			if ( $f['media_type'] === 'video' ) {
-				$hasVideo = true;
-			}
-		}
-		$out->addHTML( '</table>' );
-
-		$out->addHTML( '<p class="uc-draft-expires">Draft ID: ' .
-			htmlspecialchars( $draft['draft_id'] ) .
-			' · Expires: ' . htmlspecialchars( $draft['expires_at'] ) . '</p>' );
-
-		// Metadata form
-		$out->addHTML( Html::openElement( 'form', [
-			'method' => 'post',
-			'action' => $this->getPageTitle()->getLocalURL( [ 'action' => 'finalize' ] ),
-		] ) );
-
-		$out->addHTML( Html::input( 'wpEditToken', $this->getUser()->getEditToken(), 'hidden' ) );
-		$out->addHTML( Html::input( 'draft_id', $draft['draft_id'], 'hidden' ) );
-
-		// Pre-fill title from first file
-		$defaultTitle = '';
-		if ( count( $draft['files'] ) === 1 && !empty( $draft['files'][0]['detected_title'] ) ) {
-			$defaultTitle = $draft['files'][0]['detected_title'];
-		}
-
-		$out->addHTML( '<div class="uc-field">' );
-		$out->addHTML( Html::element( 'label', [ 'for' => 'uc-title' ], 'Title' ) );
-		$out->addHTML( Html::input( 'title', $defaultTitle, 'text', [
-			'id' => 'uc-title',
-			'class' => 'cdx-text-input__input',
-			'placeholder' => 'Content title',
-		] ) );
-		$out->addHTML( '</div>' );
-
-		$out->addHTML( '<div class="uc-field">' );
-		$out->addHTML( Html::element( 'label', [ 'for' => 'uc-description' ], 'Description' ) );
-		$out->addHTML( Html::textarea( 'description', '', [
-			'id' => 'uc-description',
-			'class' => 'cdx-text-input__input',
-			'rows' => 3,
-			'placeholder' => 'Optional description',
-		] ) );
-		$out->addHTML( '</div>' );
-
-		$out->addHTML( '<div class="uc-field">' );
-		$out->addHTML( Html::element( 'label', [ 'for' => 'uc-file-type' ], 'File type override' ) );
-		$out->addHTML( Html::input( 'file_type', '', 'text', [
-			'id' => 'uc-file-type',
-			'class' => 'cdx-text-input__input',
-			'placeholder' => 'e.g., video/webm (leave blank for auto)',
-		] ) );
-		$out->addHTML( '</div>' );
-
-		$out->addHTML( '<div class="uc-field">' );
-		$out->addHTML( Html::element( 'label', [ 'for' => 'uc-subsequent-to' ], 'Subsequent to (CID)' ) );
-		$out->addHTML( Html::input( 'subsequent_to', '', 'text', [
-			'id' => 'uc-subsequent-to',
-			'class' => 'cdx-text-input__input',
-			'placeholder' => 'CID this content supersedes',
-		] ) );
-		$out->addHTML( '</div>' );
-
-		if ( $hasVideo ) {
-			$out->addHTML( '<div class="uc-field uc-checkbox-field">' );
-			$out->addHTML( '<label>' );
-			$out->addHTML( Html::check( 'transcode_hls', false ) );
-			$out->addHTML( ' Transcode video to HLS before pinning</label>' );
-			$out->addHTML( '</div>' );
-		}
-
-		$out->addHTML( '<div class="uc-button-row">' );
-		$out->addHTML( Html::submitButton( 'Finalize & Pin to IPFS', [
-			'class' => 'cdx-button cdx-button--action-progressive cdx-button--weight-primary',
-		] ) );
-
-		// Delete draft button (separate form)
-		$out->addHTML( '</div>' );
-		$out->addHTML( Html::closeElement( 'form' ) );
-
-		$out->addHTML( Html::openElement( 'form', [
-			'method' => 'post',
-			'action' => $this->getPageTitle()->getLocalURL( [ 'action' => 'delete' ] ),
-			'style' => 'display:inline; margin-top:0.5em;',
-		] ) );
-		$out->addHTML( Html::input( 'wpEditToken', $this->getUser()->getEditToken(), 'hidden' ) );
-		$out->addHTML( Html::input( 'draft_id', $draft['draft_id'], 'hidden' ) );
-		$out->addHTML( Html::submitButton( 'Delete Draft', [
-			'class' => 'cdx-button cdx-button--action-destructive',
-		] ) );
-		$out->addHTML( Html::closeElement( 'form' ) );
-
-		$out->addHTML( '</div>' );
-	}
-
-	/**
-	 * Retrieve an existing draft and show the review form.
-	 */
-	private function showReviewStep( string $draftId ): void {
-		$out = $this->getOutput();
-		$apiUrl = $this->getConfig()->get( 'DeliveryKidUrl' );
-		$apiKey = $this->getConfig()->get( 'DeliveryKidApiKey' );
-
-		$curl = curl_init( $apiUrl . '/draft-content/' . urlencode( $draftId ) );
-		curl_setopt_array( $curl, [
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_HTTPHEADER => [
-				'X-API-Key: ' . $apiKey,
-				'X-Uploaded-By: wiki:' . $this->getUser()->getName(),
-			],
-			CURLOPT_TIMEOUT => 30,
-		] );
-
-		$response = curl_exec( $curl );
-		$httpCode = curl_getinfo( $curl, CURLINFO_HTTP_CODE );
-		curl_close( $curl );
-
-		$data = json_decode( $response, true );
-
-		if ( $httpCode !== 200 || !$data ) {
-			$detail = $data['detail'] ?? 'Draft not found or expired.';
-			$out->addHTML( '<div class="uc-status uc-status-error">' .
-				htmlspecialchars( $detail ) . '</div>' );
-			$this->showUploadForm();
-			return;
-		}
-
-		$this->showReviewForm( $data );
-	}
-
-	/**
-	 * Handle finalization — POST to delivery-kid, consume SSE stream, show result.
-	 */
-	private function handleFinalize( \MediaWiki\Request\WebRequest $request ): void {
-		$out = $this->getOutput();
-		$user = $this->getUser();
-
-		if ( !$user->matchEditToken( $request->getVal( 'wpEditToken' ) ) ) {
-			$out->addHTML( '<div class="uc-status uc-status-error">Invalid session token.</div>' );
-			return;
-		}
-
-		$draftId = $request->getVal( 'draft_id' );
-		if ( !$draftId ) {
-			$out->addHTML( '<div class="uc-status uc-status-error">Missing draft ID.</div>' );
-			return;
-		}
-
-		$apiUrl = $this->getConfig()->get( 'DeliveryKidUrl' );
-		$apiKey = $this->getConfig()->get( 'DeliveryKidApiKey' );
-
-		$body = json_encode( [
-			'title' => $request->getVal( 'title' ) ?: null,
-			'description' => $request->getVal( 'description' ) ?: null,
-			'file_type' => $request->getVal( 'file_type' ) ?: null,
-			'subsequent_to' => $request->getVal( 'subsequent_to' ) ?: null,
-			'transcode_hls' => (bool)$request->getVal( 'transcode_hls' ),
-			'metadata' => [],
-		] );
-
-		$curl = curl_init( $apiUrl . '/draft-content/' . urlencode( $draftId ) . '/finalize' );
-		curl_setopt_array( $curl, [
-			CURLOPT_POST => true,
-			CURLOPT_POSTFIELDS => $body,
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_HTTPHEADER => [
-				'Content-Type: application/json',
-				'X-API-Key: ' . $apiKey,
-				'X-Uploaded-By: wiki:' . $user->getName(),
-			],
-			CURLOPT_TIMEOUT => 600, // Transcoding can take a while
-		] );
-
-		$response = curl_exec( $curl );
-		$httpCode = curl_getinfo( $curl, CURLINFO_HTTP_CODE );
-		$curlError = curl_error( $curl );
-		curl_close( $curl );
-
-		if ( $curlError ) {
-			$out->addHTML( '<div class="uc-status uc-status-error">Connection error: ' .
-				htmlspecialchars( $curlError ) . '</div>' );
-			return;
-		}
-
-		if ( $httpCode !== 200 ) {
-			$data = json_decode( $response, true );
-			$detail = $data['detail'] ?? $response;
-			$out->addHTML( '<div class="uc-status uc-status-error">Finalization failed (' .
-				$httpCode . '): ' . htmlspecialchars( $detail ) . '</div>' );
-			return;
-		}
-
-		// Parse SSE response to find the final 'complete' or 'error' event
-		$result = $this->parseSSEResponse( $response );
-
-		if ( $result === null ) {
-			$out->addHTML( '<div class="uc-status uc-status-error">Unexpected response from pinning service.</div>' );
-			return;
-		}
-
-		if ( isset( $result['error'] ) ) {
-			$out->addHTML( '<div class="uc-status uc-status-error">Pinning failed: ' .
-				htmlspecialchars( $result['error'] ) . '</div>' );
-			return;
-		}
-
-		// Success — show result
-		$this->showResult( $result );
-	}
-
-	/**
-	 * Handle draft deletion.
-	 */
-	private function handleDelete( \MediaWiki\Request\WebRequest $request ): void {
-		$out = $this->getOutput();
-		$user = $this->getUser();
-
-		if ( !$user->matchEditToken( $request->getVal( 'wpEditToken' ) ) ) {
-			$out->addHTML( '<div class="uc-status uc-status-error">Invalid session token.</div>' );
-			return;
-		}
-
-		$draftId = $request->getVal( 'draft_id' );
-		$apiUrl = $this->getConfig()->get( 'DeliveryKidUrl' );
-		$apiKey = $this->getConfig()->get( 'DeliveryKidApiKey' );
-
-		$curl = curl_init( $apiUrl . '/draft-content/' . urlencode( $draftId ) );
-		curl_setopt_array( $curl, [
-			CURLOPT_CUSTOMREQUEST => 'DELETE',
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_HTTPHEADER => [
-				'X-API-Key: ' . $apiKey,
-				'X-Uploaded-By: wiki:' . $user->getName(),
-			],
-			CURLOPT_TIMEOUT => 30,
-		] );
-
-		curl_exec( $curl );
-		curl_close( $curl );
-
-		$out->addHTML( '<div class="uc-status uc-status-success">Draft deleted.</div>' );
-		$this->showUploadForm();
-	}
-
-	/**
-	 * Parse an SSE response body and return the data from the last meaningful event.
-	 *
-	 * @param string $response Raw SSE response
-	 * @return array|null Parsed data from 'complete' or 'error' event
-	 */
-	private function parseSSEResponse( string $response ): ?array {
-		$lastEvent = '';
-		$lastData = null;
-
-		foreach ( explode( "\n", $response ) as $line ) {
-			$line = trim( $line );
-			if ( str_starts_with( $line, 'event:' ) ) {
-				$lastEvent = trim( substr( $line, 6 ) );
-			} elseif ( str_starts_with( $line, 'data:' ) ) {
-				$json = trim( substr( $line, 5 ) );
-				$parsed = json_decode( $json, true );
-				if ( $parsed !== null ) {
-					if ( $lastEvent === 'complete' ) {
-						return $parsed;
-					} elseif ( $lastEvent === 'error' ) {
-						return [ 'error' => $parsed['message'] ?? 'Unknown error' ];
-					}
-					$lastData = $parsed;
-				}
-			}
-		}
-
-		return $lastData;
-	}
-
-	/**
-	 * Show pinning result with CID and links.
-	 */
-	private function showResult( array $data ): void {
-		$out = $this->getOutput();
-
-		$out->addHTML( '<div class="uc-step uc-step-active">' );
-		$out->addHTML( '<div class="uc-result-card">' );
-		$out->addHTML( Html::element( 'h3', [], 'Content Pinned Successfully' ) );
-
-		$out->addHTML( '<table class="wikitable">' );
-
-		if ( !empty( $data['title'] ) ) {
-			$out->addHTML( '<tr>' . Html::element( 'th', [], 'Title' ) .
-				Html::element( 'td', [], $data['title'] ) . '</tr>' );
-		}
-
-		$cid = $data['cid'] ?? '';
-		$out->addHTML( '<tr>' . Html::element( 'th', [], 'CID' ) .
-			Html::element( 'td', [ 'class' => 'release-cid-cell' ], $cid ) . '</tr>' );
-
-		if ( !empty( $data['gateway_url'] ) ) {
-			$out->addHTML( '<tr>' . Html::element( 'th', [], 'Gateway' ) .
-				'<td>' . Html::element( 'a', [
-					'href' => $data['gateway_url'],
-					'target' => '_blank',
-				], $data['gateway_url'] ) . '</td></tr>' );
-		}
-
-		$pinata = !empty( $data['pinata'] ) ? 'Yes' : 'No';
-		$out->addHTML( '<tr>' . Html::element( 'th', [], 'Pinata' ) .
-			Html::element( 'td', [], $pinata ) . '</tr>' );
-
-		if ( !empty( $data['subsequent_to'] ) ) {
-			$out->addHTML( '<tr>' . Html::element( 'th', [], 'Supersedes' ) .
-				Html::element( 'td', [], $data['subsequent_to'] ) . '</tr>' );
-		}
-
-		$out->addHTML( '</table>' );
-
-		// Link to Release page
-		if ( $cid ) {
-			$releaseTitle = \Title::makeTitle( NS_RELEASE, $cid );
-			if ( $releaseTitle ) {
-				$out->addHTML( '<p>' . Html::element( 'a', [
-					'href' => $releaseTitle->getLocalURL(),
-					'class' => 'cdx-button cdx-button--action-progressive',
-				], 'View Release Page' ) . '</p>' );
-			}
-		}
-
-		$out->addHTML( '<p>' . Html::element( 'a', [
-			'href' => $this->getPageTitle()->getLocalURL(),
-			'class' => 'cdx-button',
-		], 'Upload More Content' ) . '</p>' );
-
-		$out->addHTML( '</div></div>' );
+	private function renderPageStructure(): string {
+		$html = '';
+
+		// Step 1: File upload
+		$html .= '<div id="uc-step-upload" class="uc-step uc-step-active">';
+		$html .= '<h3>Upload Files</h3>';
+		$html .= '<p>Select files to upload for review before pinning to IPFS.</p>';
+		$html .= '<div id="uc-dropzone" class="uc-dropzone">';
+		$html .= '<p>Drag files here or click to select</p>';
+		$html .= '<p class="uc-hint">Audio, Video, Images &mdash; no size limit</p>';
+		$html .= '<input type="file" id="uc-file-input" multiple style="display:none">';
+		$html .= '</div>';
+		$html .= '<div id="uc-file-list" class="uc-file-list"></div>';
+		$html .= '<button id="uc-upload-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary" disabled>Upload &amp; Analyze</button>';
+		$html .= '<div id="uc-upload-progress" class="uc-progress-bar" style="display:none"><div class="uc-progress-fill"></div></div>';
+		$html .= '<div id="uc-upload-status" class="uc-status"></div>';
+		$html .= '</div>';
+
+		// Step 2: Review and metadata
+		$html .= '<div id="uc-step-review" class="uc-step">';
+		$html .= '<h3>Review &amp; Metadata</h3>';
+		$html .= '<div id="uc-draft-info" class="uc-draft-info"></div>';
+		$html .= '<div class="uc-metadata-form">';
+		$html .= '<div class="uc-field"><label for="uc-title">Title</label>';
+		$html .= '<input type="text" id="uc-title" class="cdx-text-input__input" placeholder="Content title"></div>';
+		$html .= '<div class="uc-field"><label for="uc-description">Description</label>';
+		$html .= '<textarea id="uc-description" class="cdx-text-input__input" rows="3" placeholder="Optional description"></textarea></div>';
+		$html .= '<div class="uc-field"><label for="uc-file-type">File type override</label>';
+		$html .= '<input type="text" id="uc-file-type" class="cdx-text-input__input" placeholder="e.g., video/webm (leave blank for auto)"></div>';
+		$html .= '<div class="uc-field"><label for="uc-subsequent-to">Subsequent to (CID)</label>';
+		$html .= '<input type="text" id="uc-subsequent-to" class="cdx-text-input__input" placeholder="CID this content supersedes"></div>';
+		$html .= '<div class="uc-field uc-checkbox-field" id="uc-hls-field" style="display:none">';
+		$html .= '<label><input type="checkbox" id="uc-transcode-hls"> Transcode video to HLS before pinning</label></div>';
+		$html .= '</div>';
+		$html .= '<div class="uc-button-row">';
+		$html .= '<button id="uc-finalize-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">Finalize &amp; Pin</button>';
+		$html .= '<button id="uc-delete-draft-btn" class="cdx-button cdx-button--action-destructive">Delete Draft</button>';
+		$html .= '</div>';
+		$html .= '</div>';
+
+		// Step 3: Progress and result
+		$html .= '<div id="uc-step-progress" class="uc-step">';
+		$html .= '<h3>Pinning</h3>';
+		$html .= '<div id="uc-progress-bar" class="uc-progress-bar"><div class="uc-progress-fill"></div></div>';
+		$html .= '<div id="uc-progress-status" class="uc-status"></div>';
+		$html .= '<div id="uc-result" class="uc-result"></div>';
+		$html .= '</div>';
+
+		return $html;
 	}
 
 	/**
@@ -559,20 +121,6 @@ class SpecialUploadContent extends SpecialPage {
 		if ( !$msg->isDisabled() ) {
 			$this->getOutput()->addWikiTextAsInterface( $msg->plain() );
 		}
-	}
-
-	/**
-	 * Format file size in human-readable format.
-	 */
-	private function formatFileSize( int $bytes ): string {
-		$units = [ 'B', 'KB', 'MB', 'GB' ];
-		$size = (float)$bytes;
-		$i = 0;
-		while ( $size >= 1024 && $i < count( $units ) - 1 ) {
-			$size /= 1024;
-			$i++;
-		}
-		return round( $size, 1 ) . ' ' . $units[$i];
 	}
 
 	/**

--- a/extensions/PickiPediaReleases/src/SpecialUploadContent.php
+++ b/extensions/PickiPediaReleases/src/SpecialUploadContent.php
@@ -2,11 +2,12 @@
 /**
  * Special page for uploading content to delivery-kid pinning service.
  *
- * Provides a multi-step workflow:
- * 1. Connect wallet (MetaMask)
- * 2. Upload files -> creates draft on delivery-kid
- * 3. Review analysis, edit metadata
- * 4. Finalize -> transcode (if needed) + pin to IPFS
+ * Wiki login is the auth layer. PHP proxies uploads to delivery-kid
+ * using a shared API key — no wallet connection needed.
+ *
+ * Two-step flow:
+ * 1. Upload files → shows analysis/preview
+ * 2. Review metadata, finalize → pins to IPFS, shows result
  *
  * @file
  * @ingroup Extensions
@@ -14,6 +15,7 @@
 
 namespace MediaWiki\Extension\PickiPediaReleases;
 
+use MediaWiki\Html\Html;
 use MediaWiki\SpecialPage\SpecialPage;
 
 class SpecialUploadContent extends SpecialPage {
@@ -29,80 +31,524 @@ class SpecialUploadContent extends SpecialPage {
 		$this->setHeaders();
 		$this->checkPermissions();
 		$out = $this->getOutput();
+		$request = $this->getRequest();
 
 		$out->addModuleStyles( [ 'ext.pickipediaReleases.upload.styles' ] );
-		$out->addModules( [ 'ext.pickipediaReleases.upload' ] );
-
-		// Pass config to JS
-		$out->addJsConfigVars( [
-			'wgDeliveryKidUrl' => $this->getConfig()->get( 'DeliveryKidUrl' ),
-		] );
 
 		// Editable intro text
 		$this->addWikitextMessage( 'special-uploadcontent-header' );
 
-		$out->addHTML( $this->renderPageStructure() );
+		$action = $request->getVal( 'action', '' );
+
+		if ( $action === 'finalize' ) {
+			$this->handleFinalize( $request );
+		} elseif ( $action === 'delete' ) {
+			$this->handleDelete( $request );
+		} elseif ( $action === 'upload' && $request->wasPosted() ) {
+			$this->handleUpload( $request );
+		} elseif ( $request->getVal( 'draft_id' ) ) {
+			$this->showReviewStep( $request->getVal( 'draft_id' ) );
+		} else {
+			$this->showUploadForm();
+		}
 	}
 
 	/**
-	 * Render the HTML skeleton for the upload workflow.
-	 * JS handles all interactivity.
+	 * Step 1: Show the file upload form.
 	 */
-	private function renderPageStructure(): string {
-		$html = '';
+	private function showUploadForm(): void {
+		$out = $this->getOutput();
 
-		// Step 1: Wallet connection
-		$html .= '<div id="uc-step-wallet" class="uc-step uc-step-active">';
-		$html .= '<h3>Step 1: Connect Wallet</h3>';
-		$html .= '<p>Connect your Ethereum wallet to authenticate with the pinning service.</p>';
-		$html .= '<button id="uc-connect-wallet" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">Connect Wallet</button>';
-		$html .= '<div id="uc-wallet-status" class="uc-status"></div>';
-		$html .= '</div>';
+		$out->addHTML( '<div class="uc-step uc-step-active">' );
+		$out->addHTML( Html::element( 'h3', [], 'Upload Files' ) );
+		$out->addHTML( '<p>Select files to upload for review before pinning to IPFS.</p>' );
+		$out->addHTML( '<p class="uc-hint">Audio (FLAC, WAV, MP3, OGG), ' .
+			'Video (MP4, WebM, MOV, MKV), Images (JPG, PNG, WebP, GIF)</p>' );
 
-		// Step 2: File upload
-		$html .= '<div id="uc-step-upload" class="uc-step">';
-		$html .= '<h3>Step 2: Upload Files</h3>';
-		$html .= '<div id="uc-dropzone" class="uc-dropzone">';
-		$html .= '<p>Drag files here or click to select</p>';
-		$html .= '<p class="uc-hint">Audio (FLAC, WAV, MP3, OGG, M4A, AAC, OPUS), ';
-		$html .= 'Video (MP4, WebM, MOV, MKV, AVI), ';
-		$html .= 'Images (JPG, PNG, WebP, GIF)</p>';
-		$html .= '<input type="file" id="uc-file-input" multiple style="display:none">';
-		$html .= '</div>';
-		$html .= '<div id="uc-file-list" class="uc-file-list"></div>';
-		$html .= '<button id="uc-upload-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary" disabled>Upload Files</button>';
-		$html .= '<div id="uc-upload-status" class="uc-status"></div>';
-		$html .= '</div>';
+		$out->addHTML( Html::openElement( 'form', [
+			'method' => 'post',
+			'enctype' => 'multipart/form-data',
+			'action' => $this->getPageTitle()->getLocalURL( [ 'action' => 'upload' ] ),
+		] ) );
 
-		// Step 3: Review and metadata
-		$html .= '<div id="uc-step-review" class="uc-step">';
-		$html .= '<h3>Step 3: Review &amp; Metadata</h3>';
-		$html .= '<div id="uc-draft-info" class="uc-draft-info"></div>';
-		$html .= '<div class="uc-metadata-form">';
-		$html .= '<div class="uc-field"><label for="uc-title">Title</label>';
-		$html .= '<input type="text" id="uc-title" class="cdx-text-input__input" placeholder="Content title"></div>';
-		$html .= '<div class="uc-field"><label for="uc-description">Description</label>';
-		$html .= '<textarea id="uc-description" class="cdx-text-input__input" rows="3" placeholder="Optional description"></textarea></div>';
-		$html .= '<div class="uc-field"><label for="uc-file-type">File type override</label>';
-		$html .= '<input type="text" id="uc-file-type" class="cdx-text-input__input" placeholder="e.g., video/webm (leave blank for auto)"></div>';
-		$html .= '<div class="uc-field"><label for="uc-subsequent-to">Subsequent to (CID)</label>';
-		$html .= '<input type="text" id="uc-subsequent-to" class="cdx-text-input__input" placeholder="CID this content supersedes"></div>';
-		$html .= '<div class="uc-field uc-checkbox-field">';
-		$html .= '<label><input type="checkbox" id="uc-transcode-hls"> Transcode video to HLS before pinning</label></div>';
-		$html .= '</div>';
-		$html .= '<button id="uc-finalize-btn" class="cdx-button cdx-button--action-progressive cdx-button--weight-primary">Finalize &amp; Pin</button>';
-		$html .= '<button id="uc-delete-draft-btn" class="cdx-button cdx-button--action-destructive">Delete Draft</button>';
-		$html .= '</div>';
+		$out->addHTML( Html::input( 'wpEditToken', $this->getUser()->getEditToken(), 'hidden' ) );
 
-		// Step 4: Progress and result
-		$html .= '<div id="uc-step-progress" class="uc-step">';
-		$html .= '<h3>Step 4: Pinning</h3>';
-		$html .= '<div id="uc-progress-bar" class="uc-progress-bar"><div class="uc-progress-fill"></div></div>';
-		$html .= '<div id="uc-progress-status" class="uc-status"></div>';
-		$html .= '<div id="uc-result" class="uc-result"></div>';
-		$html .= '</div>';
+		$out->addHTML( '<div class="uc-field">' );
+		$out->addHTML( Html::element( 'label', [ 'for' => 'uc-files' ], 'Files' ) );
+		$out->addHTML( Html::input( 'files[]', '', 'file', [
+			'id' => 'uc-files',
+			'multiple' => true,
+			'accept' => '.flac,.wav,.mp3,.ogg,.m4a,.aac,.opus,.mp4,.webm,.mov,.mkv,.avi,.ts,.jpg,.jpeg,.png,.webp,.gif,.svg',
+		] ) );
+		$out->addHTML( '</div>' );
 
-		return $html;
+		$out->addHTML( Html::submitButton( 'Upload & Analyze', [
+			'class' => 'cdx-button cdx-button--action-progressive cdx-button--weight-primary',
+		] ) );
+
+		$out->addHTML( Html::closeElement( 'form' ) );
+		$out->addHTML( '</div>' );
+	}
+
+	/**
+	 * Handle file upload POST — send files to delivery-kid, show review form.
+	 */
+	private function handleUpload( \MediaWiki\Request\WebRequest $request ): void {
+		$out = $this->getOutput();
+		$user = $this->getUser();
+
+		if ( !$user->matchEditToken( $request->getVal( 'wpEditToken' ) ) ) {
+			$out->addHTML( '<div class="uc-status uc-status-error">Invalid session token. Please try again.</div>' );
+			$this->showUploadForm();
+			return;
+		}
+
+		$uploadedFiles = $request->getUploadDir() !== null ? $_FILES['files'] ?? null : null;
+		// Fallback: PHP populates $_FILES directly
+		if ( $uploadedFiles === null ) {
+			$uploadedFiles = $_FILES['files'] ?? null;
+		}
+
+		if ( !$uploadedFiles || empty( $uploadedFiles['name'][0] ) ) {
+			$out->addHTML( '<div class="uc-status uc-status-error">No files selected.</div>' );
+			$this->showUploadForm();
+			return;
+		}
+
+		$apiUrl = $this->getConfig()->get( 'DeliveryKidUrl' );
+		$apiKey = $this->getConfig()->get( 'DeliveryKidApiKey' );
+
+		// Build multipart POST to delivery-kid
+		$curl = curl_init( $apiUrl . '/draft-content' );
+		$postFields = [];
+
+		// PHP receives multiple files as arrays of names/tmp_names/etc.
+		$fileCount = count( $uploadedFiles['name'] );
+		for ( $i = 0; $i < $fileCount; $i++ ) {
+			if ( $uploadedFiles['error'][$i] !== UPLOAD_ERR_OK ) {
+				continue;
+			}
+			$postFields["files[$i]"] = new \CURLFile(
+				$uploadedFiles['tmp_name'][$i],
+				$uploadedFiles['type'][$i],
+				$uploadedFiles['name'][$i]
+			);
+		}
+
+		if ( empty( $postFields ) ) {
+			$out->addHTML( '<div class="uc-status uc-status-error">No valid files to upload.</div>' );
+			$this->showUploadForm();
+			return;
+		}
+
+		curl_setopt_array( $curl, [
+			CURLOPT_POST => true,
+			CURLOPT_POSTFIELDS => $postFields,
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_HTTPHEADER => [
+				'X-API-Key: ' . $apiKey,
+				'X-Uploaded-By: wiki:' . $user->getName(),
+			],
+			CURLOPT_TIMEOUT => 120,
+		] );
+
+		$response = curl_exec( $curl );
+		$httpCode = curl_getinfo( $curl, CURLINFO_HTTP_CODE );
+		$curlError = curl_error( $curl );
+		curl_close( $curl );
+
+		if ( $curlError ) {
+			$out->addHTML( '<div class="uc-status uc-status-error">Connection error: ' .
+				htmlspecialchars( $curlError ) . '</div>' );
+			$this->showUploadForm();
+			return;
+		}
+
+		$data = json_decode( $response, true );
+
+		if ( $httpCode !== 200 || !$data ) {
+			$detail = $data['detail'] ?? $response;
+			$out->addHTML( '<div class="uc-status uc-status-error">Upload failed (' .
+				$httpCode . '): ' . htmlspecialchars( $detail ) . '</div>' );
+			$this->showUploadForm();
+			return;
+		}
+
+		$this->showReviewForm( $data );
+	}
+
+	/**
+	 * Step 2: Show review form with file analysis and metadata fields.
+	 */
+	private function showReviewForm( array $draft ): void {
+		$out = $this->getOutput();
+
+		$out->addHTML( '<div class="uc-step uc-step-active">' );
+		$out->addHTML( Html::element( 'h3', [], 'Review & Finalize' ) );
+
+		// File analysis table
+		$out->addHTML( '<table class="wikitable">' );
+		$out->addHTML( '<tr><th>File</th><th>Type</th><th>Format</th><th>Duration</th><th>Size</th></tr>' );
+
+		$hasVideo = false;
+		foreach ( $draft['files'] as $f ) {
+			$out->addHTML( '<tr>' );
+			$out->addHTML( Html::element( 'td', [], $f['original_filename'] ) );
+			$out->addHTML( Html::element( 'td', [], $f['media_type'] ) );
+			$out->addHTML( Html::element( 'td', [], $f['format'] ) );
+			$duration = '';
+			if ( !empty( $f['duration_seconds'] ) ) {
+				$m = floor( $f['duration_seconds'] / 60 );
+				$s = floor( $f['duration_seconds'] ) % 60;
+				$duration = sprintf( '%d:%02d', $m, $s );
+			}
+			$out->addHTML( Html::element( 'td', [], $duration ) );
+			$out->addHTML( Html::element( 'td', [], $this->formatFileSize( $f['size_bytes'] ) ) );
+			$out->addHTML( '</tr>' );
+
+			if ( !empty( $f['width'] ) && !empty( $f['height'] ) ) {
+				$details = $f['width'] . 'x' . $f['height'];
+				if ( !empty( $f['video_codec'] ) ) {
+					$details .= ' · ' . $f['video_codec'];
+				}
+				if ( !empty( $f['audio_codec'] ) ) {
+					$details .= ' · ' . $f['audio_codec'];
+				}
+				$out->addHTML( '<tr><td></td><td colspan="4">' .
+					htmlspecialchars( $details ) . '</td></tr>' );
+			}
+
+			if ( $f['media_type'] === 'video' ) {
+				$hasVideo = true;
+			}
+		}
+		$out->addHTML( '</table>' );
+
+		$out->addHTML( '<p class="uc-draft-expires">Draft ID: ' .
+			htmlspecialchars( $draft['draft_id'] ) .
+			' · Expires: ' . htmlspecialchars( $draft['expires_at'] ) . '</p>' );
+
+		// Metadata form
+		$out->addHTML( Html::openElement( 'form', [
+			'method' => 'post',
+			'action' => $this->getPageTitle()->getLocalURL( [ 'action' => 'finalize' ] ),
+		] ) );
+
+		$out->addHTML( Html::input( 'wpEditToken', $this->getUser()->getEditToken(), 'hidden' ) );
+		$out->addHTML( Html::input( 'draft_id', $draft['draft_id'], 'hidden' ) );
+
+		// Pre-fill title from first file
+		$defaultTitle = '';
+		if ( count( $draft['files'] ) === 1 && !empty( $draft['files'][0]['detected_title'] ) ) {
+			$defaultTitle = $draft['files'][0]['detected_title'];
+		}
+
+		$out->addHTML( '<div class="uc-field">' );
+		$out->addHTML( Html::element( 'label', [ 'for' => 'uc-title' ], 'Title' ) );
+		$out->addHTML( Html::input( 'title', $defaultTitle, 'text', [
+			'id' => 'uc-title',
+			'class' => 'cdx-text-input__input',
+			'placeholder' => 'Content title',
+		] ) );
+		$out->addHTML( '</div>' );
+
+		$out->addHTML( '<div class="uc-field">' );
+		$out->addHTML( Html::element( 'label', [ 'for' => 'uc-description' ], 'Description' ) );
+		$out->addHTML( Html::textarea( 'description', '', [
+			'id' => 'uc-description',
+			'class' => 'cdx-text-input__input',
+			'rows' => 3,
+			'placeholder' => 'Optional description',
+		] ) );
+		$out->addHTML( '</div>' );
+
+		$out->addHTML( '<div class="uc-field">' );
+		$out->addHTML( Html::element( 'label', [ 'for' => 'uc-file-type' ], 'File type override' ) );
+		$out->addHTML( Html::input( 'file_type', '', 'text', [
+			'id' => 'uc-file-type',
+			'class' => 'cdx-text-input__input',
+			'placeholder' => 'e.g., video/webm (leave blank for auto)',
+		] ) );
+		$out->addHTML( '</div>' );
+
+		$out->addHTML( '<div class="uc-field">' );
+		$out->addHTML( Html::element( 'label', [ 'for' => 'uc-subsequent-to' ], 'Subsequent to (CID)' ) );
+		$out->addHTML( Html::input( 'subsequent_to', '', 'text', [
+			'id' => 'uc-subsequent-to',
+			'class' => 'cdx-text-input__input',
+			'placeholder' => 'CID this content supersedes',
+		] ) );
+		$out->addHTML( '</div>' );
+
+		if ( $hasVideo ) {
+			$out->addHTML( '<div class="uc-field uc-checkbox-field">' );
+			$out->addHTML( '<label>' );
+			$out->addHTML( Html::check( 'transcode_hls', false ) );
+			$out->addHTML( ' Transcode video to HLS before pinning</label>' );
+			$out->addHTML( '</div>' );
+		}
+
+		$out->addHTML( '<div class="uc-button-row">' );
+		$out->addHTML( Html::submitButton( 'Finalize & Pin to IPFS', [
+			'class' => 'cdx-button cdx-button--action-progressive cdx-button--weight-primary',
+		] ) );
+
+		// Delete draft button (separate form)
+		$out->addHTML( '</div>' );
+		$out->addHTML( Html::closeElement( 'form' ) );
+
+		$out->addHTML( Html::openElement( 'form', [
+			'method' => 'post',
+			'action' => $this->getPageTitle()->getLocalURL( [ 'action' => 'delete' ] ),
+			'style' => 'display:inline; margin-top:0.5em;',
+		] ) );
+		$out->addHTML( Html::input( 'wpEditToken', $this->getUser()->getEditToken(), 'hidden' ) );
+		$out->addHTML( Html::input( 'draft_id', $draft['draft_id'], 'hidden' ) );
+		$out->addHTML( Html::submitButton( 'Delete Draft', [
+			'class' => 'cdx-button cdx-button--action-destructive',
+		] ) );
+		$out->addHTML( Html::closeElement( 'form' ) );
+
+		$out->addHTML( '</div>' );
+	}
+
+	/**
+	 * Retrieve an existing draft and show the review form.
+	 */
+	private function showReviewStep( string $draftId ): void {
+		$out = $this->getOutput();
+		$apiUrl = $this->getConfig()->get( 'DeliveryKidUrl' );
+		$apiKey = $this->getConfig()->get( 'DeliveryKidApiKey' );
+
+		$curl = curl_init( $apiUrl . '/draft-content/' . urlencode( $draftId ) );
+		curl_setopt_array( $curl, [
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_HTTPHEADER => [
+				'X-API-Key: ' . $apiKey,
+				'X-Uploaded-By: wiki:' . $this->getUser()->getName(),
+			],
+			CURLOPT_TIMEOUT => 30,
+		] );
+
+		$response = curl_exec( $curl );
+		$httpCode = curl_getinfo( $curl, CURLINFO_HTTP_CODE );
+		curl_close( $curl );
+
+		$data = json_decode( $response, true );
+
+		if ( $httpCode !== 200 || !$data ) {
+			$detail = $data['detail'] ?? 'Draft not found or expired.';
+			$out->addHTML( '<div class="uc-status uc-status-error">' .
+				htmlspecialchars( $detail ) . '</div>' );
+			$this->showUploadForm();
+			return;
+		}
+
+		$this->showReviewForm( $data );
+	}
+
+	/**
+	 * Handle finalization — POST to delivery-kid, consume SSE stream, show result.
+	 */
+	private function handleFinalize( \MediaWiki\Request\WebRequest $request ): void {
+		$out = $this->getOutput();
+		$user = $this->getUser();
+
+		if ( !$user->matchEditToken( $request->getVal( 'wpEditToken' ) ) ) {
+			$out->addHTML( '<div class="uc-status uc-status-error">Invalid session token.</div>' );
+			return;
+		}
+
+		$draftId = $request->getVal( 'draft_id' );
+		if ( !$draftId ) {
+			$out->addHTML( '<div class="uc-status uc-status-error">Missing draft ID.</div>' );
+			return;
+		}
+
+		$apiUrl = $this->getConfig()->get( 'DeliveryKidUrl' );
+		$apiKey = $this->getConfig()->get( 'DeliveryKidApiKey' );
+
+		$body = json_encode( [
+			'title' => $request->getVal( 'title' ) ?: null,
+			'description' => $request->getVal( 'description' ) ?: null,
+			'file_type' => $request->getVal( 'file_type' ) ?: null,
+			'subsequent_to' => $request->getVal( 'subsequent_to' ) ?: null,
+			'transcode_hls' => (bool)$request->getVal( 'transcode_hls' ),
+			'metadata' => [],
+		] );
+
+		$curl = curl_init( $apiUrl . '/draft-content/' . urlencode( $draftId ) . '/finalize' );
+		curl_setopt_array( $curl, [
+			CURLOPT_POST => true,
+			CURLOPT_POSTFIELDS => $body,
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_HTTPHEADER => [
+				'Content-Type: application/json',
+				'X-API-Key: ' . $apiKey,
+				'X-Uploaded-By: wiki:' . $user->getName(),
+			],
+			CURLOPT_TIMEOUT => 600, // Transcoding can take a while
+		] );
+
+		$response = curl_exec( $curl );
+		$httpCode = curl_getinfo( $curl, CURLINFO_HTTP_CODE );
+		$curlError = curl_error( $curl );
+		curl_close( $curl );
+
+		if ( $curlError ) {
+			$out->addHTML( '<div class="uc-status uc-status-error">Connection error: ' .
+				htmlspecialchars( $curlError ) . '</div>' );
+			return;
+		}
+
+		if ( $httpCode !== 200 ) {
+			$data = json_decode( $response, true );
+			$detail = $data['detail'] ?? $response;
+			$out->addHTML( '<div class="uc-status uc-status-error">Finalization failed (' .
+				$httpCode . '): ' . htmlspecialchars( $detail ) . '</div>' );
+			return;
+		}
+
+		// Parse SSE response to find the final 'complete' or 'error' event
+		$result = $this->parseSSEResponse( $response );
+
+		if ( $result === null ) {
+			$out->addHTML( '<div class="uc-status uc-status-error">Unexpected response from pinning service.</div>' );
+			return;
+		}
+
+		if ( isset( $result['error'] ) ) {
+			$out->addHTML( '<div class="uc-status uc-status-error">Pinning failed: ' .
+				htmlspecialchars( $result['error'] ) . '</div>' );
+			return;
+		}
+
+		// Success — show result
+		$this->showResult( $result );
+	}
+
+	/**
+	 * Handle draft deletion.
+	 */
+	private function handleDelete( \MediaWiki\Request\WebRequest $request ): void {
+		$out = $this->getOutput();
+		$user = $this->getUser();
+
+		if ( !$user->matchEditToken( $request->getVal( 'wpEditToken' ) ) ) {
+			$out->addHTML( '<div class="uc-status uc-status-error">Invalid session token.</div>' );
+			return;
+		}
+
+		$draftId = $request->getVal( 'draft_id' );
+		$apiUrl = $this->getConfig()->get( 'DeliveryKidUrl' );
+		$apiKey = $this->getConfig()->get( 'DeliveryKidApiKey' );
+
+		$curl = curl_init( $apiUrl . '/draft-content/' . urlencode( $draftId ) );
+		curl_setopt_array( $curl, [
+			CURLOPT_CUSTOMREQUEST => 'DELETE',
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_HTTPHEADER => [
+				'X-API-Key: ' . $apiKey,
+				'X-Uploaded-By: wiki:' . $user->getName(),
+			],
+			CURLOPT_TIMEOUT => 30,
+		] );
+
+		curl_exec( $curl );
+		curl_close( $curl );
+
+		$out->addHTML( '<div class="uc-status uc-status-success">Draft deleted.</div>' );
+		$this->showUploadForm();
+	}
+
+	/**
+	 * Parse an SSE response body and return the data from the last meaningful event.
+	 *
+	 * @param string $response Raw SSE response
+	 * @return array|null Parsed data from 'complete' or 'error' event
+	 */
+	private function parseSSEResponse( string $response ): ?array {
+		$lastEvent = '';
+		$lastData = null;
+
+		foreach ( explode( "\n", $response ) as $line ) {
+			$line = trim( $line );
+			if ( str_starts_with( $line, 'event:' ) ) {
+				$lastEvent = trim( substr( $line, 6 ) );
+			} elseif ( str_starts_with( $line, 'data:' ) ) {
+				$json = trim( substr( $line, 5 ) );
+				$parsed = json_decode( $json, true );
+				if ( $parsed !== null ) {
+					if ( $lastEvent === 'complete' ) {
+						return $parsed;
+					} elseif ( $lastEvent === 'error' ) {
+						return [ 'error' => $parsed['message'] ?? 'Unknown error' ];
+					}
+					$lastData = $parsed;
+				}
+			}
+		}
+
+		return $lastData;
+	}
+
+	/**
+	 * Show pinning result with CID and links.
+	 */
+	private function showResult( array $data ): void {
+		$out = $this->getOutput();
+
+		$out->addHTML( '<div class="uc-step uc-step-active">' );
+		$out->addHTML( '<div class="uc-result-card">' );
+		$out->addHTML( Html::element( 'h3', [], 'Content Pinned Successfully' ) );
+
+		$out->addHTML( '<table class="wikitable">' );
+
+		if ( !empty( $data['title'] ) ) {
+			$out->addHTML( '<tr>' . Html::element( 'th', [], 'Title' ) .
+				Html::element( 'td', [], $data['title'] ) . '</tr>' );
+		}
+
+		$cid = $data['cid'] ?? '';
+		$out->addHTML( '<tr>' . Html::element( 'th', [], 'CID' ) .
+			Html::element( 'td', [ 'class' => 'release-cid-cell' ], $cid ) . '</tr>' );
+
+		if ( !empty( $data['gateway_url'] ) ) {
+			$out->addHTML( '<tr>' . Html::element( 'th', [], 'Gateway' ) .
+				'<td>' . Html::element( 'a', [
+					'href' => $data['gateway_url'],
+					'target' => '_blank',
+				], $data['gateway_url'] ) . '</td></tr>' );
+		}
+
+		$pinata = !empty( $data['pinata'] ) ? 'Yes' : 'No';
+		$out->addHTML( '<tr>' . Html::element( 'th', [], 'Pinata' ) .
+			Html::element( 'td', [], $pinata ) . '</tr>' );
+
+		if ( !empty( $data['subsequent_to'] ) ) {
+			$out->addHTML( '<tr>' . Html::element( 'th', [], 'Supersedes' ) .
+				Html::element( 'td', [], $data['subsequent_to'] ) . '</tr>' );
+		}
+
+		$out->addHTML( '</table>' );
+
+		// Link to Release page
+		if ( $cid ) {
+			$releaseTitle = \Title::makeTitle( NS_RELEASE, $cid );
+			if ( $releaseTitle ) {
+				$out->addHTML( '<p>' . Html::element( 'a', [
+					'href' => $releaseTitle->getLocalURL(),
+					'class' => 'cdx-button cdx-button--action-progressive',
+				], 'View Release Page' ) . '</p>' );
+			}
+		}
+
+		$out->addHTML( '<p>' . Html::element( 'a', [
+			'href' => $this->getPageTitle()->getLocalURL(),
+			'class' => 'cdx-button',
+		], 'Upload More Content' ) . '</p>' );
+
+		$out->addHTML( '</div></div>' );
 	}
 
 	/**
@@ -113,6 +559,20 @@ class SpecialUploadContent extends SpecialPage {
 		if ( !$msg->isDisabled() ) {
 			$this->getOutput()->addWikiTextAsInterface( $msg->plain() );
 		}
+	}
+
+	/**
+	 * Format file size in human-readable format.
+	 */
+	private function formatFileSize( int $bytes ): string {
+		$units = [ 'B', 'KB', 'MB', 'GB' ];
+		$size = (float)$bytes;
+		$i = 0;
+		while ( $size >= 1024 && $i < count( $units ) - 1 ) {
+			$size /= 1024;
+			$i++;
+		}
+		return round( $size, 1 ) . ' ' . $units[$i];
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- `createReleasePage()` now writes `bittorrent_infohash` and `bittorrent_trackers` to Release YAML when present in the finalize complete event
- `detectStage()` recognizes torrent-related SSE messages for progress UI
- Stage pipeline adds "Torrenting" step between Pinning and Complete

Companion to delivery-kid torrent generation (maybelle-config PR #68).

## Test plan
- [ ] Finalize a draft album — should show Torrenting stage in progress UI
- [ ] Resulting Release page should have magnet link if delivery-kid returns infohash
- [ ] Finalize still works if torrent generation fails (non-fatal)