### PR TITLE
Embed video preview on ReleaseDraft pages

### DIFF
--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -253,6 +253,18 @@
 	margin-bottom: 1em;
 }
 
+/* Video preview */
+.rd-video-preview {
+	margin: 1.5em 0;
+}
+
+.rd-video-player {
+	width: 100%;
+	max-width: 800px;
+	background: #000;
+	border-radius: 4px;
+}
+
 /* Raw YAML toggle */
 .release-raw-yaml {
 	margin-top: 2em;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -954,6 +954,40 @@
 		} );
 	}
 
+	// -- Video preview --
+
+	function initVideoPreview() {
+		var video = el( 'rd-video-player' );
+		if ( !video ) {
+			return;
+		}
+
+		var deliveryKidUrl = mw.config.get( 'wgDeliveryKidUrl' );
+		var token = mw.config.get( 'wgUploadToken' );
+		var user = mw.config.get( 'wgUploadUser' );
+		var timestamp = mw.config.get( 'wgUploadTimestamp' );
+		var draftId = video.getAttribute( 'data-draft-id' );
+		var filename = video.getAttribute( 'data-filename' );
+
+		if ( !deliveryKidUrl || !token || !draftId || !filename ) {
+			// Not logged in or missing config — hide the player
+			var container = el( 'rd-video-preview' );
+			if ( container ) {
+				container.style.display = 'none';
+			}
+			return;
+		}
+
+		var src = deliveryKidUrl + '/staging/drafts/' +
+			encodeURIComponent( draftId ) + '/' +
+			encodeURIComponent( filename ) +
+			'?token=' + encodeURIComponent( token ) +
+			'&user=' + encodeURIComponent( user ) +
+			'&timestamp=' + encodeURIComponent( timestamp );
+
+		video.src = src;
+	}
+
 	// -- Init --
 
 	function init() {
@@ -961,6 +995,7 @@
 		initSaveButton();
 		initFinalizeButton();
 		initBlockheightConverter();
+		initVideoPreview();
 	}
 
 	mw.loader.using( [ 'mediawiki.util', 'mediawiki.api' ] ).then( init );

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -489,6 +489,27 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 
 			$html .= Html::closeElement( 'table' );
 
+			// Embed video player for preview (JS sets src with auth query params)
+			$draftId = $data['draft_id'] ?? '';
+			foreach ( $files as $f ) {
+				if ( ( $f['media_type'] ?? '' ) === 'video' && $draftId ) {
+					$html .= Html::rawElement( 'div', [
+						'class' => 'rd-video-preview',
+						'id' => 'rd-video-preview',
+					],
+						Html::element( 'video', [
+							'id' => 'rd-video-player',
+							'class' => 'rd-video-player',
+							'controls' => true,
+							'preload' => 'metadata',
+							'data-draft-id' => $draftId,
+							'data-filename' => $f['original_filename'] ?? '',
+						] )
+					);
+					break; // Only embed first video
+				}
+			}
+
 			$html .= Html::rawElement( 'p', [ 'class' => 'uc-hls-info' ],
 				'Video will be transcoded to AV1 HLS (royalty-free) automatically on finalization.' );
 		}


### PR DESCRIPTION
## Summary

- Adds an embedded `<video>` player on ReleaseDraft pages when the draft contains a video file
- Video is served from delivery-kid's new `/staging/drafts/{id}/{filename}` endpoint (maybelle-config #73)
- Auth tokens are passed via query parameters (`?token=&user=&timestamp=`) since `<video src>` tags can't send custom headers

## Changes

- **ReleaseDraftContentHandler.php** — renders a `<video>` element with `data-draft-id` and `data-filename` attributes when the draft has a video file
- **releaseDraft.js** — `initVideoPreview()` constructs the authenticated video src URL from `wgDeliveryKidUrl` and HMAC token config vars
- **releaseDraft.css** — styles for the video preview container and player

## Dependencies

Requires maybelle-config #73 (staging file endpoint) to be deployed for the video to actually load.

## Test plan

- [ ] Visit a ReleaseDraft page with a video file — player should appear and play
- [ ] Visit a ReleaseDraft page without video files — no player shown
- [ ] Verify video seeking works (HTTP range requests via FileResponse)
- [ ] Confirm non-logged-in users don't see a broken player (hidden when no token available)