### PR TITLE
Add video trim controls to ReleaseDraft pages

### DIFF
--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -265,6 +265,54 @@
 	border-radius: 4px;
 }
 
+/* Trim controls */
+.rd-trim-controls {
+	margin: 0.75em 0 1.5em;
+	max-width: 800px;
+}
+
+.rd-trim-controls h4 {
+	margin: 0 0 0.5em;
+	font-size: 0.95em;
+}
+
+.rd-trim-row {
+	display: flex;
+	gap: 1.5em;
+	flex-wrap: wrap;
+}
+
+.rd-trim-field {
+	display: flex;
+	align-items: center;
+	gap: 0.5em;
+}
+
+.rd-trim-field label {
+	font-weight: bold;
+	font-size: 0.9em;
+	color: #54595d;
+}
+
+.rd-trim-input {
+	width: 5em;
+	text-align: center;
+	font-family: monospace;
+}
+
+.rd-trim-set-btn {
+	font-size: 0.85em;
+	padding: 0.25em 0.6em;
+	cursor: pointer;
+}
+
+.rd-trim-preview {
+	margin-top: 0.5em;
+	font-size: 0.85em;
+	color: #54595d;
+	font-style: italic;
+}
+
 /* Raw YAML toggle */
 .release-raw-yaml {
 	margin-top: 2em;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -185,6 +185,19 @@
 					return s.length > 0;
 				} );
 			}
+			// Trim points
+			var trimStartEl = el( 'rd-trim-start' );
+			var trimEndEl = el( 'rd-trim-end' );
+			if ( trimStartEl && trimStartEl.value.trim() ) {
+				data.content.trim_start_seconds = parseTime( trimStartEl.value );
+			} else {
+				delete data.content.trim_start_seconds;
+			}
+			if ( trimEndEl && trimEndEl.value.trim() ) {
+				data.content.trim_end_seconds = parseTime( trimEndEl.value );
+			} else {
+				delete data.content.trim_end_seconds;
+			}
 		} else {
 			// Content fields (other, blue-railroad, etc.)
 			if ( !data.content ) {
@@ -341,6 +354,12 @@
 			( vidContent.performers || [] ).forEach( function ( p ) {
 				lines.push( '        - ' + quoteYamlValue( p ) );
 			} );
+			if ( vidContent.trim_start_seconds !== null && vidContent.trim_start_seconds !== undefined ) {
+				lines.push( '    trim_start_seconds: ' + vidContent.trim_start_seconds );
+			}
+			if ( vidContent.trim_end_seconds !== null && vidContent.trim_end_seconds !== undefined ) {
+				lines.push( '    trim_end_seconds: ' + vidContent.trim_end_seconds );
+			}
 
 			if ( data.files && data.files.length > 0 ) {
 				lines.push( 'files:' );
@@ -954,7 +973,66 @@
 		} );
 	}
 
-	// -- Video preview --
+	// -- Video preview & trim --
+
+	function formatTime( seconds ) {
+		if ( seconds === null || seconds === undefined || seconds === '' ) {
+			return '';
+		}
+		var s = parseFloat( seconds );
+		if ( isNaN( s ) ) {
+			return '';
+		}
+		var m = Math.floor( s / 60 );
+		var sec = s - m * 60;
+		return m + ':' + ( sec < 10 ? '0' : '' ) + sec.toFixed( 1 );
+	}
+
+	function parseTime( str ) {
+		if ( !str || !str.trim() ) {
+			return null;
+		}
+		str = str.trim();
+		// Accept m:ss.s or just seconds
+		var parts = str.split( ':' );
+		if ( parts.length === 2 ) {
+			return parseFloat( parts[ 0 ] ) * 60 + parseFloat( parts[ 1 ] );
+		}
+		var val = parseFloat( str );
+		return isNaN( val ) ? null : val;
+	}
+
+	function updateTrimPreview() {
+		var preview = el( 'rd-trim-preview' );
+		if ( !preview ) {
+			return;
+		}
+		var video = el( 'rd-video-player' );
+		var startInput = el( 'rd-trim-start' );
+		var endInput = el( 'rd-trim-end' );
+		if ( !startInput || !endInput ) {
+			return;
+		}
+
+		var start = parseTime( startInput.value );
+		var end = parseTime( endInput.value );
+		var duration = video ? video.duration : null;
+
+		var parts = [];
+		if ( start !== null && start > 0 ) {
+			parts.push( 'trimming first ' + formatTime( start ) );
+		}
+		if ( end !== null && duration && end < duration ) {
+			parts.push( 'trimming last ' + formatTime( duration - end ) );
+		}
+		if ( start !== null && end !== null ) {
+			var outputDuration = end - start;
+			if ( outputDuration > 0 ) {
+				parts.push( 'output duration: ' + formatTime( outputDuration ) );
+			}
+		}
+		preview.textContent = parts.length > 0 ? parts.join( ' · ' ) : '';
+	}
 
 	function initVideoPreview() {
 		var video = el( 'rd-video-player' );
@@ -975,6 +1053,10 @@
 			if ( container ) {
 				container.style.display = 'none';
 			}
+			var trimControls = el( 'rd-trim-controls' );
+			if ( trimControls ) {
+				trimControls.style.display = 'none';
+			}
 			return;
 		}
 
@@ -986,6 +1068,35 @@
 			'&timestamp=' + encodeURIComponent( timestamp );
 
 		video.src = src;
+
+		// "Set start" / "Set end" buttons grab current playback position
+		var setStartBtn = el( 'rd-trim-set-start' );
+		var setEndBtn = el( 'rd-trim-set-end' );
+		var startInput = el( 'rd-trim-start' );
+		var endInput = el( 'rd-trim-end' );
+
+		if ( setStartBtn && startInput ) {
+			setStartBtn.addEventListener( 'click', function () {
+				startInput.value = formatTime( video.currentTime );
+				updateTrimPreview();
+			} );
+		}
+		if ( setEndBtn && endInput ) {
+			setEndBtn.addEventListener( 'click', function () {
+				endInput.value = formatTime( video.currentTime );
+				updateTrimPreview();
+			} );
+		}
+		if ( startInput ) {
+			startInput.addEventListener( 'input', updateTrimPreview );
+		}
+		if ( endInput ) {
+			endInput.addEventListener( 'input', updateTrimPreview );
+		}
+
+		// Update preview once video metadata is loaded (to know total duration)
+		video.addEventListener( 'loadedmetadata', updateTrimPreview );
+		updateTrimPreview();
 	}
 
 	// -- Init --

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -506,6 +506,63 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 							'data-filename' => $f['original_filename'] ?? '',
 						] )
 					);
+
+					// Trim controls — set start/end from current playback position
+					$trimStart = $data['content']['trim_start_seconds'] ?? '';
+					$trimEnd = $data['content']['trim_end_seconds'] ?? '';
+					$disabled = ( $status !== 'draft' ) ? [ 'disabled' => true ] : [];
+
+					$html .= Html::openElement( 'div', [
+						'class' => 'rd-trim-controls',
+						'id' => 'rd-trim-controls',
+					] );
+					$html .= Html::element( 'h4', [], 'Trim' );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-row' ] );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
+					$html .= Html::element( 'label', [ 'for' => 'rd-trim-start' ], 'Start' );
+					$html .= Html::element( 'input', array_merge( [
+						'type' => 'text',
+						'id' => 'rd-trim-start',
+						'class' => 'rd-trim-input',
+						'value' => $trimStart,
+						'placeholder' => '0:00',
+						'size' => 8,
+					], $disabled ) );
+					$html .= Html::element( 'button', array_merge( [
+						'type' => 'button',
+						'id' => 'rd-trim-set-start',
+						'class' => 'rd-trim-set-btn',
+					], $disabled ), 'Set start' );
+					$html .= Html::closeElement( 'div' );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
+					$html .= Html::element( 'label', [ 'for' => 'rd-trim-end' ], 'End' );
+					$html .= Html::element( 'input', array_merge( [
+						'type' => 'text',
+						'id' => 'rd-trim-end',
+						'class' => 'rd-trim-input',
+						'value' => $trimEnd,
+						'placeholder' => '0:00',
+						'size' => 8,
+					], $disabled ) );
+					$html .= Html::element( 'button', array_merge( [
+						'type' => 'button',
+						'id' => 'rd-trim-set-end',
+						'class' => 'rd-trim-set-btn',
+					], $disabled ), 'Set end' );
+					$html .= Html::closeElement( 'div' );
+
+					$html .= Html::closeElement( 'div' ); // .rd-trim-row
+
+					$html .= Html::element( 'div', [
+						'class' => 'rd-trim-preview',
+						'id' => 'rd-trim-preview',
+					] );
+
+					$html .= Html::closeElement( 'div' ); // .rd-trim-controls
+
 					break; // Only embed first video
 				}
 			}


### PR DESCRIPTION
## Summary

- Adds start/end trim controls below the video player on ReleaseDraft pages
- "Set start" and "Set end" buttons capture the current video playback position
- Values stored as `trim_start_seconds` and `trim_end_seconds` in the draft YAML `content:` block
- Preview line shows what will be trimmed and the resulting output duration
- Controls are disabled when draft status is not `draft` (finalized/finalizing)

## How it works

1. Play the video, pause where you want it to start
2. Click **Set start** — fills the start time from the player position
3. Play to where you want it to end
4. Click **Set end** — fills the end time
5. Save the draft — trim values are persisted in the YAML
6. On finalize, delivery-kid passes these to Coconut (`offset`/`duration`) or ffmpeg (`-ss`/`-to`)

## Dependencies

- Requires #62 (video preview embed) — the trim controls sit below the video player
- delivery-kid finalize endpoint needs to read and apply trim params (separate PR in maybelle-config)

## Test plan

- [ ] Visit a video ReleaseDraft — trim controls appear below the video
- [ ] Play video, pause, click "Set start" — input populated with m:ss.s format
- [ ] Click "Set end" — input populated, preview line shows trim summary
- [ ] Save draft — YAML includes `trim_start_seconds` and `trim_end_seconds`
- [ ] Reload page — trim values restored from YAML
- [ ] Non-draft status — trim inputs are disabled
- [ ] Clear both inputs, save — trim fields removed from YAML