### PR TITLE
Polish ReleaseDraft page: friendlier date, collapsed settings

### DIFF
--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverBlueRailroad.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverBlueRailroad.js
@@ -102,16 +102,31 @@
 			updateBlockDateLabel( block, dateLabel );
 		} );
 
-		// Date picker → block height conversion
+		// Date picker → block height conversion (Etherscan API with local fallback)
 		var dateInput = el( 'dv-date-input' );
 		if ( dateInput ) {
 			dateInput.addEventListener( 'change', function () {
 				if ( dateInput.value ) {
 					var parts = dateInput.value.split( '-' );
 					var ts = Math.floor( new Date( parts[ 0 ], parts[ 1 ] - 1, parts[ 2 ], 12, 0, 0 ).getTime() / 1000 );
+					// Local estimate while API is in flight
 					var block = timestampToBlock( ts );
 					bhInput.value = block;
 					updateBlockDateLabel( block, dateLabel );
+					// Fetch exact block
+					fetch( 'https://api.etherscan.io/api?module=block&action=getblocknobytime' +
+						'&timestamp=' + ts + '&closest=before' )
+						.then( function ( r ) { return r.json(); } )
+						.then( function ( resp ) {
+							if ( resp.status === '1' && resp.result ) {
+								var exact = parseInt( resp.result, 10 );
+								if ( exact > 0 ) {
+									bhInput.value = exact;
+									updateBlockDateLabel( exact, dateLabel );
+								}
+							}
+						} )
+						.catch( function () {} );
 				}
 			} );
 		}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
@@ -106,17 +106,31 @@
 			updateBlockDateLabel( block, dateLabel );
 		} );
 
-		// Date picker → block height conversion
+		// Date picker → block height conversion (Etherscan API with local fallback)
 		var dateInput = el( 'dv-date-input' );
 		if ( dateInput ) {
 			dateInput.addEventListener( 'change', function () {
 				if ( dateInput.value ) {
-					// Parse date at noon local time to avoid timezone offset issues
 					var parts = dateInput.value.split( '-' );
 					var ts = Math.floor( new Date( parts[ 0 ], parts[ 1 ] - 1, parts[ 2 ], 12, 0, 0 ).getTime() / 1000 );
+					// Local estimate while API is in flight
 					var block = timestampToBlock( ts );
 					bhInput.value = block;
 					updateBlockDateLabel( block, dateLabel );
+					// Fetch exact block
+					fetch( 'https://api.etherscan.io/api?module=block&action=getblocknobytime' +
+						'&timestamp=' + ts + '&closest=before' )
+						.then( function ( r ) { return r.json(); } )
+						.then( function ( resp ) {
+							if ( resp.status === '1' && resp.result ) {
+								var exact = parseInt( resp.result, 10 );
+								if ( exact > 0 ) {
+									bhInput.value = exact;
+									updateBlockDateLabel( exact, dateLabel );
+								}
+							}
+						} )
+						.catch( function () {} );
 				}
 			} );
 		}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
@@ -360,7 +360,27 @@
 			if ( f.size_bytes ) {
 				lines.push( '        size_bytes: ' + f.size_bytes );
 			}
+			if ( f.creation_time ) {
+				lines.push( '        creation_time: ' + quoteYamlValue( f.creation_time ) );
+			}
 		} );
+
+		// If the user hasn't picked a date and the video has creation_time
+		// metadata, use it as the default content date.
+		var contentDateInput = el( 'dv-content-date' );
+		var contentBhInput = el( 'dv-content-blockheight' );
+		if ( contentDateInput && !contentDateInput.value && contentBhInput && !contentBhInput.value ) {
+			var firstFile = ( draft.files || [] )[ 0 ];
+			if ( firstFile && firstFile.creation_time ) {
+				// creation_time is ISO 8601, e.g. "2026-03-15T14:30:00.000000Z"
+				var dateStr = firstFile.creation_time.substring( 0, 10 );
+				if ( dateStr && /^\d{4}-\d{2}-\d{2}$/.test( dateStr ) ) {
+					contentDateInput.value = dateStr;
+					// Trigger change event so the blockheight converter picks it up
+					contentDateInput.dispatchEvent( new Event( 'change' ) );
+				}
+			}
+		}
 
 		return lines.join( '\n' ) + '\n';
 	}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -265,6 +265,54 @@
 	border-radius: 4px;
 }
 
+/* Trim controls */
+.rd-trim-controls {
+	margin: 0.75em 0 1.5em;
+	max-width: 800px;
+}
+
+.rd-trim-controls h4 {
+	margin: 0 0 0.5em;
+	font-size: 0.95em;
+}
+
+.rd-trim-row {
+	display: flex;
+	gap: 1.5em;
+	flex-wrap: wrap;
+}
+
+.rd-trim-field {
+	display: flex;
+	align-items: center;
+	gap: 0.5em;
+}
+
+.rd-trim-field label {
+	font-weight: bold;
+	font-size: 0.9em;
+	color: #54595d;
+}
+
+.rd-trim-input {
+	width: 5em;
+	text-align: center;
+	font-family: monospace;
+}
+
+.rd-trim-set-btn {
+	font-size: 0.85em;
+	padding: 0.25em 0.6em;
+	cursor: pointer;
+}
+
+.rd-trim-preview {
+	margin-top: 0.5em;
+	font-size: 0.85em;
+	color: #54595d;
+	font-style: italic;
+}
+
 /* Raw YAML toggle */
 .release-raw-yaml {
 	margin-top: 2em;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -313,6 +313,17 @@
 	font-style: italic;
 }
 
+/* More settings (collapsed) */
+.rd-more-settings {
+	margin: 1em 0;
+	font-size: 0.9em;
+}
+
+.rd-more-settings summary {
+	cursor: pointer;
+	color: #72777d;
+}
+
 /* Raw YAML toggle */
 .release-raw-yaml {
 	margin-top: 2em;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -185,6 +185,19 @@
 					return s.length > 0;
 				} );
 			}
+			// Trim points
+			var trimStartEl = el( 'rd-trim-start' );
+			var trimEndEl = el( 'rd-trim-end' );
+			if ( trimStartEl && trimStartEl.value.trim() ) {
+				data.content.trim_start_seconds = parseTime( trimStartEl.value );
+			} else {
+				delete data.content.trim_start_seconds;
+			}
+			if ( trimEndEl && trimEndEl.value.trim() ) {
+				data.content.trim_end_seconds = parseTime( trimEndEl.value );
+			} else {
+				delete data.content.trim_end_seconds;
+			}
 		} else {
 			// Content fields (other, blue-railroad, etc.)
 			if ( !data.content ) {
@@ -341,6 +354,12 @@
 			( vidContent.performers || [] ).forEach( function ( p ) {
 				lines.push( '        - ' + quoteYamlValue( p ) );
 			} );
+			if ( vidContent.trim_start_seconds !== null && vidContent.trim_start_seconds !== undefined ) {
+				lines.push( '    trim_start_seconds: ' + vidContent.trim_start_seconds );
+			}
+			if ( vidContent.trim_end_seconds !== null && vidContent.trim_end_seconds !== undefined ) {
+				lines.push( '    trim_end_seconds: ' + vidContent.trim_end_seconds );
+			}
 
 			if ( data.files && data.files.length > 0 ) {
 				lines.push( 'files:' );
@@ -954,7 +973,66 @@
 		} );
 	}
 
-	// -- Video preview --
+	// -- Video preview & trim --
+
+	function formatTime( seconds ) {
+		if ( seconds === null || seconds === undefined || seconds === '' ) {
+			return '';
+		}
+		var s = parseFloat( seconds );
+		if ( isNaN( s ) ) {
+			return '';
+		}
+		var m = Math.floor( s / 60 );
+		var sec = s - m * 60;
+		return m + ':' + ( sec < 10 ? '0' : '' ) + sec.toFixed( 1 );
+	}
+
+	function parseTime( str ) {
+		if ( !str || !str.trim() ) {
+			return null;
+		}
+		str = str.trim();
+		// Accept m:ss.s or just seconds
+		var parts = str.split( ':' );
+		if ( parts.length === 2 ) {
+			return parseFloat( parts[ 0 ] ) * 60 + parseFloat( parts[ 1 ] );
+		}
+		var val = parseFloat( str );
+		return isNaN( val ) ? null : val;
+	}
+
+	function updateTrimPreview() {
+		var preview = el( 'rd-trim-preview' );
+		if ( !preview ) {
+			return;
+		}
+		var video = el( 'rd-video-player' );
+		var startInput = el( 'rd-trim-start' );
+		var endInput = el( 'rd-trim-end' );
+		if ( !startInput || !endInput ) {
+			return;
+		}
+
+		var start = parseTime( startInput.value );
+		var end = parseTime( endInput.value );
+		var duration = video ? video.duration : null;
+
+		var parts = [];
+		if ( start !== null && start > 0 ) {
+			parts.push( 'trimming first ' + formatTime( start ) );
+		}
+		if ( end !== null && duration && end < duration ) {
+			parts.push( 'trimming last ' + formatTime( duration - end ) );
+		}
+		if ( start !== null && end !== null ) {
+			var outputDuration = end - start;
+			if ( outputDuration > 0 ) {
+				parts.push( 'output duration: ' + formatTime( outputDuration ) );
+			}
+		}
+		preview.textContent = parts.length > 0 ? parts.join( ' · ' ) : '';
+	}
 
 	function initVideoPreview() {
 		var video = el( 'rd-video-player' );
@@ -975,6 +1053,10 @@
 			if ( container ) {
 				container.style.display = 'none';
 			}
+			var trimControls = el( 'rd-trim-controls' );
+			if ( trimControls ) {
+				trimControls.style.display = 'none';
+			}
 			return;
 		}
 
@@ -986,6 +1068,35 @@
 			'&timestamp=' + encodeURIComponent( timestamp );
 
 		video.src = src;
+
+		// "Set start" / "Set end" buttons grab current playback position
+		var setStartBtn = el( 'rd-trim-set-start' );
+		var setEndBtn = el( 'rd-trim-set-end' );
+		var startInput = el( 'rd-trim-start' );
+		var endInput = el( 'rd-trim-end' );
+
+		if ( setStartBtn && startInput ) {
+			setStartBtn.addEventListener( 'click', function () {
+				startInput.value = formatTime( video.currentTime );
+				updateTrimPreview();
+			} );
+		}
+		if ( setEndBtn && endInput ) {
+			setEndBtn.addEventListener( 'click', function () {
+				endInput.value = formatTime( video.currentTime );
+				updateTrimPreview();
+			} );
+		}
+		if ( startInput ) {
+			startInput.addEventListener( 'input', updateTrimPreview );
+		}
+		if ( endInput ) {
+			endInput.addEventListener( 'input', updateTrimPreview );
+		}
+
+		// Update preview once video metadata is loaded (to know total duration)
+		video.addEventListener( 'loadedmetadata', updateTrimPreview );
+		updateTrimPreview();
 	}
 
 	// -- Init --

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -910,7 +910,7 @@
 			}
 		} );
 
-		// Date picker → estimate block number
+		// Date picker → look up exact block via Etherscan API
 		if ( dateInput ) {
 			dateInput.addEventListener( 'change', function () {
 				var dateStr = dateInput.value;
@@ -918,11 +918,30 @@
 					return;
 				}
 				var ts = Math.floor( new Date( dateStr + 'T12:00:00Z' ).getTime() / 1000 );
+
+				// Show local estimate immediately while API call is in flight
 				var estimated = timestampToBlock( ts );
 				if ( estimated > 0 ) {
 					bhInput.value = estimated;
 					updateBlockDate( estimated );
 				}
+
+				// Fetch exact block from Etherscan
+				fetch( 'https://api.etherscan.io/api?module=block&action=getblocknobytime' +
+					'&timestamp=' + ts + '&closest=before' )
+					.then( function ( r ) { return r.json(); } )
+					.then( function ( resp ) {
+						if ( resp.status === '1' && resp.result ) {
+							var block = parseInt( resp.result, 10 );
+							if ( block > 0 ) {
+								bhInput.value = block;
+								updateBlockDate( block );
+							}
+						}
+					} )
+					.catch( function () {
+						// Local estimate already in place, nothing to do
+					} );
 			} );
 		}
 

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -382,6 +382,9 @@
 					if ( f.size_bytes ) {
 						lines.push( '        size_bytes: ' + f.size_bytes );
 					}
+					if ( f.creation_time ) {
+						lines.push( '        creation_time: ' + quoteYamlValue( f.creation_time ) );
+					}
 				} );
 			}
 		} else if ( draftType === 'blue-railroad' ) {
@@ -1101,12 +1104,34 @@
 
 	// -- Init --
 
+	function initCreationTimeFallback() {
+		// If the date field is empty and a video file has creation_time
+		// metadata (from the camera/phone), pre-fill the date picker.
+		var dateInput = el( 'rd-date-input' );
+		var bhInput = el( 'rd-blockheight' );
+		if ( !dateInput || dateInput.value || ( bhInput && bhInput.value ) ) {
+			return;
+		}
+		var files = ( draftData && draftData.files ) || [];
+		for ( var i = 0; i < files.length; i++ ) {
+			if ( files[ i ].creation_time ) {
+				var dateStr = files[ i ].creation_time.substring( 0, 10 );
+				if ( /^\d{4}-\d{2}-\d{2}$/.test( dateStr ) ) {
+					dateInput.value = dateStr;
+					dateInput.dispatchEvent( new Event( 'change' ) );
+					break;
+				}
+			}
+		}
+	}
+
 	function init() {
 		initTrackDragReorder();
 		initSaveButton();
 		initFinalizeButton();
 		initBlockheightConverter();
 		initVideoPreview();
+		initCreationTimeFallback();
 	}
 
 	mw.loader.using( [ 'mediawiki.util', 'mediawiki.api' ] ).then( init );

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -506,6 +506,63 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 							'data-filename' => $f['original_filename'] ?? '',
 						] )
 					);
+
+					// Trim controls — set start/end from current playback position
+					$trimStart = $data['content']['trim_start_seconds'] ?? '';
+					$trimEnd = $data['content']['trim_end_seconds'] ?? '';
+					$disabled = ( $status !== 'draft' ) ? [ 'disabled' => true ] : [];
+
+					$html .= Html::openElement( 'div', [
+						'class' => 'rd-trim-controls',
+						'id' => 'rd-trim-controls',
+					] );
+					$html .= Html::element( 'h4', [], 'Trim' );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-row' ] );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
+					$html .= Html::element( 'label', [ 'for' => 'rd-trim-start' ], 'Start' );
+					$html .= Html::element( 'input', array_merge( [
+						'type' => 'text',
+						'id' => 'rd-trim-start',
+						'class' => 'rd-trim-input',
+						'value' => $trimStart,
+						'placeholder' => '0:00',
+						'size' => 8,
+					], $disabled ) );
+					$html .= Html::element( 'button', array_merge( [
+						'type' => 'button',
+						'id' => 'rd-trim-set-start',
+						'class' => 'rd-trim-set-btn',
+					], $disabled ), 'Set start' );
+					$html .= Html::closeElement( 'div' );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
+					$html .= Html::element( 'label', [ 'for' => 'rd-trim-end' ], 'End' );
+					$html .= Html::element( 'input', array_merge( [
+						'type' => 'text',
+						'id' => 'rd-trim-end',
+						'class' => 'rd-trim-input',
+						'value' => $trimEnd,
+						'placeholder' => '0:00',
+						'size' => 8,
+					], $disabled ) );
+					$html .= Html::element( 'button', array_merge( [
+						'type' => 'button',
+						'id' => 'rd-trim-set-end',
+						'class' => 'rd-trim-set-btn',
+					], $disabled ), 'Set end' );
+					$html .= Html::closeElement( 'div' );
+
+					$html .= Html::closeElement( 'div' ); // .rd-trim-row
+
+					$html .= Html::element( 'div', [
+						'class' => 'rd-trim-preview',
+						'id' => 'rd-trim-preview',
+					] );
+
+					$html .= Html::closeElement( 'div' ); // .rd-trim-controls
+
 					break; // Only embed first video
 				}
 			}

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -452,11 +452,14 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 		], $content['description'] ?? '' );
 		$html .= Html::closeElement( 'div' );
 
-		// File type override
+		$html .= Html::closeElement( 'div' );
+
+		// More settings (collapsed)
+		$html .= Html::openElement( 'details', [ 'class' => 'rd-more-settings' ] );
+		$html .= Html::element( 'summary', [], 'More settings' );
 		$html .= $this->renderField( 'rd-content-file-type', 'File type override',
 			$content['file_type'] ?? '', 'text', $disabled );
-
-		$html .= Html::closeElement( 'div' );
+		$html .= Html::closeElement( 'details' );
 
 		// File info table — media_type values ("audio", "video", "image", "other")
 		// are set by delivery-kid's analyze.detect_media_type() during upload,
@@ -579,12 +582,22 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 		$blockheight = $data['blockheight'] ?? '';
 
 		$html = Html::openElement( 'div', [ 'class' => 'rd-blockheight-section' ] );
-		$html .= Html::element( 'h3', [], 'Temporal Reference' );
+		$html .= Html::element( 'h3', [], 'When did this happen?' );
 
 		$html .= Html::openElement( 'div', [ 'class' => 'uc-field' ] );
-		$html .= Html::element( 'label', [ 'for' => 'rd-blockheight' ], 'Ethereum Block Height' );
+		$html .= Html::element( 'label', [ 'for' => 'rd-date-input' ],
+			'Approximately when did the events depicted go down?' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-date-converter' ] );
+		$html .= Html::element( 'input', [
+			'type' => 'date',
+			'id' => 'rd-date-input',
+			'class' => 'cdx-text-input__input rd-date-input',
+		] );
+		$html .= Html::closeElement( 'div' );
 
 		$html .= Html::openElement( 'div', [ 'class' => 'rd-blockheight-row' ] );
+		$html .= Html::element( 'label', [ 'for' => 'rd-blockheight' ], 'Or enter an Ethereum block height:' );
 		$html .= Html::element( 'input', [
 			'type' => 'text',
 			'id' => 'rd-blockheight',
@@ -600,28 +613,14 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 		$html .= Html::element( 'span', [ 'id' => 'rd-blockheight-date', 'class' => 'rd-blockheight-date' ], '' );
 		$html .= Html::closeElement( 'div' );
 
-		$html .= Html::openElement( 'div', [ 'class' => 'rd-date-converter' ] );
-		$html .= Html::element( 'label', [ 'for' => 'rd-date-input' ], 'Or pick a date:' );
-		$html .= Html::element( 'input', [
-			'type' => 'date',
-			'id' => 'rd-date-input',
-			'class' => 'cdx-text-input__input rd-date-input',
-		] );
-		$html .= Html::closeElement( 'div' );
-
-		// Upload blockheight — auto-captured at upload time, read-only
+		// Upload blockheight — auto-captured server-side, preserved in YAML
 		$uploadBlockheight = $data['upload_blockheight'] ?? null;
 		if ( $uploadBlockheight ) {
-			$html .= Html::openElement( 'div', [ 'class' => 'uc-field' ] );
-			$html .= Html::element( 'label', [], 'Upload block height' );
-			$html .= Html::element( 'span', [ 'class' => 'rd-upload-blockheight' ],
-				(string)$uploadBlockheight );
 			$html .= Html::element( 'input', [
 				'type' => 'hidden',
 				'id' => 'rd-upload-blockheight',
 				'value' => $uploadBlockheight,
 			] );
-			$html .= Html::closeElement( 'div' );
 		}
 
 		$html .= Html::closeElement( 'div' );


### PR DESCRIPTION
## Summary

- **"File type override"** moved into a collapsed "More settings" `<details>` — rarely used, was cluttering the form
- **Blockheight section** reworded to "When did this happen?" — date picker is now primary, block height is secondary ("Or enter an Ethereum block height")
- **Upload block height** display removed — it's computed server-side and preserved in YAML via hidden input, no need to show it
- **Video creation_time** — if the video file has creation time metadata (common from phones/cameras), the date picker is auto-filled from it

## Dependencies

- delivery-kid needs the companion change to extract `creation_time` from ffprobe output (maybelle-config PR forthcoming)
- Without the delivery-kid change, creation_time just won't be present and the auto-fill gracefully no-ops

## Test plan

- [ ] Video ReleaseDraft page: "File type override" hidden in collapsed "More settings"
- [ ] Date section says "When did this happen?" with date picker prominent
- [ ] Upload block height no longer visible (but preserved in YAML)
- [ ] Upload a video with creation_time metadata → date auto-fills
- [ ] Upload a video without creation_time → date stays empty, no errors