### PR TITLE
Preview video from IPFS, preserve-original checkbox

### DIFF
--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverBlueRailroad.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverBlueRailroad.js
@@ -102,16 +102,31 @@
 			updateBlockDateLabel( block, dateLabel );
 		} );
 
-		// Date picker → block height conversion
+		// Date picker → block height conversion (Etherscan API with local fallback)
 		var dateInput = el( 'dv-date-input' );
 		if ( dateInput ) {
 			dateInput.addEventListener( 'change', function () {
 				if ( dateInput.value ) {
 					var parts = dateInput.value.split( '-' );
 					var ts = Math.floor( new Date( parts[ 0 ], parts[ 1 ] - 1, parts[ 2 ], 12, 0, 0 ).getTime() / 1000 );
+					// Local estimate while API is in flight
 					var block = timestampToBlock( ts );
 					bhInput.value = block;
 					updateBlockDateLabel( block, dateLabel );
+					// Fetch exact block
+					fetch( 'https://api.etherscan.io/api?module=block&action=getblocknobytime' +
+						'&timestamp=' + ts + '&closest=before' )
+						.then( function ( r ) { return r.json(); } )
+						.then( function ( resp ) {
+							if ( resp.status === '1' && resp.result ) {
+								var exact = parseInt( resp.result, 10 );
+								if ( exact > 0 ) {
+									bhInput.value = exact;
+									updateBlockDateLabel( exact, dateLabel );
+								}
+							}
+						} )
+						.catch( function () {} );
 				}
 			} );
 		}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverBlueRailroad.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverBlueRailroad.js
@@ -71,11 +71,35 @@
 		if ( !labelEl || !block ) {
 			return;
 		}
+		// Local estimate immediately
 		var ts = blockToTimestamp( block );
 		var date = new Date( ts * 1000 );
 		labelEl.textContent = '≈ ' + date.toLocaleDateString( undefined, {
 			year: 'numeric', month: 'short', day: 'numeric'
 		} );
+		// Fetch exact timestamp via public RPC
+		var hexBlock = '0x' + block.toString( 16 );
+		fetch( 'https://ethereum-rpc.publicnode.com', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify( {
+				jsonrpc: '2.0',
+				method: 'eth_getBlockByNumber',
+				params: [ hexBlock, false ],
+				id: 1
+			} )
+		} )
+			.then( function ( r ) { return r.json(); } )
+			.then( function ( resp ) {
+				if ( resp.result && resp.result.timestamp ) {
+					var exactTs = parseInt( resp.result.timestamp, 16 );
+					var exactDate = new Date( exactTs * 1000 );
+					labelEl.textContent = exactDate.toLocaleDateString( undefined, {
+						year: 'numeric', month: 'short', day: 'numeric'
+					} );
+				}
+			} )
+			.catch( function () {} );
 	}
 
 	function initBlockheightControls() {

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverBlueRailroad.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverBlueRailroad.js
@@ -71,13 +71,7 @@
 		if ( !labelEl || !block ) {
 			return;
 		}
-		// Local estimate immediately
-		var ts = blockToTimestamp( block );
-		var date = new Date( ts * 1000 );
-		labelEl.textContent = '≈ ' + date.toLocaleDateString( undefined, {
-			year: 'numeric', month: 'short', day: 'numeric'
-		} );
-		// Fetch exact timestamp via public RPC
+		labelEl.textContent = '⏳';
 		var hexBlock = '0x' + block.toString( 16 );
 		fetch( 'https://ethereum-rpc.publicnode.com', {
 			method: 'POST',
@@ -92,14 +86,18 @@
 			.then( function ( r ) { return r.json(); } )
 			.then( function ( resp ) {
 				if ( resp.result && resp.result.timestamp ) {
-					var exactTs = parseInt( resp.result.timestamp, 16 );
-					var exactDate = new Date( exactTs * 1000 );
-					labelEl.textContent = exactDate.toLocaleDateString( undefined, {
+					var ts = parseInt( resp.result.timestamp, 16 );
+					var date = new Date( ts * 1000 );
+					labelEl.textContent = date.toLocaleDateString( undefined, {
 						year: 'numeric', month: 'short', day: 'numeric'
 					} );
+				} else {
+					labelEl.textContent = '';
 				}
 			} )
-			.catch( function () {} );
+			.catch( function () {
+				labelEl.textContent = '';
+			} );
 	}
 
 	function initBlockheightControls() {
@@ -126,31 +124,16 @@
 			updateBlockDateLabel( block, dateLabel );
 		} );
 
-		// Date picker → block height conversion (Etherscan API with local fallback)
+		// Date picker → estimate block from date (local formula, day-level precision)
 		var dateInput = el( 'dv-date-input' );
 		if ( dateInput ) {
 			dateInput.addEventListener( 'change', function () {
 				if ( dateInput.value ) {
 					var parts = dateInput.value.split( '-' );
 					var ts = Math.floor( new Date( parts[ 0 ], parts[ 1 ] - 1, parts[ 2 ], 12, 0, 0 ).getTime() / 1000 );
-					// Local estimate while API is in flight
 					var block = timestampToBlock( ts );
 					bhInput.value = block;
 					updateBlockDateLabel( block, dateLabel );
-					// Fetch exact block
-					fetch( 'https://api.etherscan.io/api?module=block&action=getblocknobytime' +
-						'&timestamp=' + ts + '&closest=before' )
-						.then( function ( r ) { return r.json(); } )
-						.then( function ( resp ) {
-							if ( resp.status === '1' && resp.result ) {
-								var exact = parseInt( resp.result, 10 );
-								if ( exact > 0 ) {
-									bhInput.value = exact;
-									updateBlockDateLabel( exact, dateLabel );
-								}
-							}
-						} )
-						.catch( function () {} );
 				}
 			} );
 		}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
@@ -73,11 +73,35 @@
 		if ( !labelEl || !block ) {
 			return;
 		}
+		// Local estimate immediately
 		var ts = blockToTimestamp( block );
 		var date = new Date( ts * 1000 );
 		labelEl.textContent = '≈ ' + date.toLocaleDateString( undefined, {
 			year: 'numeric', month: 'short', day: 'numeric'
 		} );
+		// Fetch exact timestamp via public RPC
+		var hexBlock = '0x' + block.toString( 16 );
+		fetch( 'https://ethereum-rpc.publicnode.com', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify( {
+				jsonrpc: '2.0',
+				method: 'eth_getBlockByNumber',
+				params: [ hexBlock, false ],
+				id: 1
+			} )
+		} )
+			.then( function ( r ) { return r.json(); } )
+			.then( function ( resp ) {
+				if ( resp.result && resp.result.timestamp ) {
+					var exactTs = parseInt( resp.result.timestamp, 16 );
+					var exactDate = new Date( exactTs * 1000 );
+					labelEl.textContent = exactDate.toLocaleDateString( undefined, {
+						year: 'numeric', month: 'short', day: 'numeric'
+					} );
+				}
+			} )
+			.catch( function () {} );
 	}
 
 	function initBlockheightControls() {

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
@@ -106,17 +106,31 @@
 			updateBlockDateLabel( block, dateLabel );
 		} );
 
-		// Date picker → block height conversion
+		// Date picker → block height conversion (Etherscan API with local fallback)
 		var dateInput = el( 'dv-date-input' );
 		if ( dateInput ) {
 			dateInput.addEventListener( 'change', function () {
 				if ( dateInput.value ) {
-					// Parse date at noon local time to avoid timezone offset issues
 					var parts = dateInput.value.split( '-' );
 					var ts = Math.floor( new Date( parts[ 0 ], parts[ 1 ] - 1, parts[ 2 ], 12, 0, 0 ).getTime() / 1000 );
+					// Local estimate while API is in flight
 					var block = timestampToBlock( ts );
 					bhInput.value = block;
 					updateBlockDateLabel( block, dateLabel );
+					// Fetch exact block
+					fetch( 'https://api.etherscan.io/api?module=block&action=getblocknobytime' +
+						'&timestamp=' + ts + '&closest=before' )
+						.then( function ( r ) { return r.json(); } )
+						.then( function ( resp ) {
+							if ( resp.status === '1' && resp.result ) {
+								var exact = parseInt( resp.result, 10 );
+								if ( exact > 0 ) {
+									bhInput.value = exact;
+									updateBlockDateLabel( exact, dateLabel );
+								}
+							}
+						} )
+						.catch( function () {} );
 				}
 			} );
 		}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
@@ -360,7 +360,27 @@
 			if ( f.size_bytes ) {
 				lines.push( '        size_bytes: ' + f.size_bytes );
 			}
+			if ( f.creation_time ) {
+				lines.push( '        creation_time: ' + quoteYamlValue( f.creation_time ) );
+			}
 		} );
+
+		// If the user hasn't picked a date and the video has creation_time
+		// metadata, use it as the default content date.
+		var contentDateInput = el( 'dv-content-date' );
+		var contentBhInput = el( 'dv-content-blockheight' );
+		if ( contentDateInput && !contentDateInput.value && contentBhInput && !contentBhInput.value ) {
+			var firstFile = ( draft.files || [] )[ 0 ];
+			if ( firstFile && firstFile.creation_time ) {
+				// creation_time is ISO 8601, e.g. "2026-03-15T14:30:00.000000Z"
+				var dateStr = firstFile.creation_time.substring( 0, 10 );
+				if ( dateStr && /^\d{4}-\d{2}-\d{2}$/.test( dateStr ) ) {
+					contentDateInput.value = dateStr;
+					// Trigger change event so the blockheight converter picks it up
+					contentDateInput.dispatchEvent( new Event( 'change' ) );
+				}
+			}
+		}
 
 		return lines.join( '\n' ) + '\n';
 	}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.deliverVideo.js
@@ -73,13 +73,7 @@
 		if ( !labelEl || !block ) {
 			return;
 		}
-		// Local estimate immediately
-		var ts = blockToTimestamp( block );
-		var date = new Date( ts * 1000 );
-		labelEl.textContent = '≈ ' + date.toLocaleDateString( undefined, {
-			year: 'numeric', month: 'short', day: 'numeric'
-		} );
-		// Fetch exact timestamp via public RPC
+		labelEl.textContent = '⏳';
 		var hexBlock = '0x' + block.toString( 16 );
 		fetch( 'https://ethereum-rpc.publicnode.com', {
 			method: 'POST',
@@ -94,14 +88,18 @@
 			.then( function ( r ) { return r.json(); } )
 			.then( function ( resp ) {
 				if ( resp.result && resp.result.timestamp ) {
-					var exactTs = parseInt( resp.result.timestamp, 16 );
-					var exactDate = new Date( exactTs * 1000 );
-					labelEl.textContent = exactDate.toLocaleDateString( undefined, {
+					var ts = parseInt( resp.result.timestamp, 16 );
+					var date = new Date( ts * 1000 );
+					labelEl.textContent = date.toLocaleDateString( undefined, {
 						year: 'numeric', month: 'short', day: 'numeric'
 					} );
+				} else {
+					labelEl.textContent = '';
 				}
 			} )
-			.catch( function () {} );
+			.catch( function () {
+				labelEl.textContent = '';
+			} );
 	}
 
 	function initBlockheightControls() {
@@ -130,31 +128,16 @@
 			updateBlockDateLabel( block, dateLabel );
 		} );
 
-		// Date picker → block height conversion (Etherscan API with local fallback)
+		// Date picker → estimate block from date (local formula, day-level precision)
 		var dateInput = el( 'dv-date-input' );
 		if ( dateInput ) {
 			dateInput.addEventListener( 'change', function () {
 				if ( dateInput.value ) {
 					var parts = dateInput.value.split( '-' );
 					var ts = Math.floor( new Date( parts[ 0 ], parts[ 1 ] - 1, parts[ 2 ], 12, 0, 0 ).getTime() / 1000 );
-					// Local estimate while API is in flight
 					var block = timestampToBlock( ts );
 					bhInput.value = block;
 					updateBlockDateLabel( block, dateLabel );
-					// Fetch exact block
-					fetch( 'https://api.etherscan.io/api?module=block&action=getblocknobytime' +
-						'&timestamp=' + ts + '&closest=before' )
-						.then( function ( r ) { return r.json(); } )
-						.then( function ( resp ) {
-							if ( resp.status === '1' && resp.result ) {
-								var exact = parseInt( resp.result, 10 );
-								if ( exact > 0 ) {
-									bhInput.value = exact;
-									updateBlockDateLabel( exact, dateLabel );
-								}
-							}
-						} )
-						.catch( function () {} );
 				}
 			} );
 		}

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -265,6 +265,54 @@
 	border-radius: 4px;
 }
 
+/* Trim controls */
+.rd-trim-controls {
+	margin: 0.75em 0 1.5em;
+	max-width: 800px;
+}
+
+.rd-trim-controls h4 {
+	margin: 0 0 0.5em;
+	font-size: 0.95em;
+}
+
+.rd-trim-row {
+	display: flex;
+	gap: 1.5em;
+	flex-wrap: wrap;
+}
+
+.rd-trim-field {
+	display: flex;
+	align-items: center;
+	gap: 0.5em;
+}
+
+.rd-trim-field label {
+	font-weight: bold;
+	font-size: 0.9em;
+	color: #54595d;
+}
+
+.rd-trim-input {
+	width: 5em;
+	text-align: center;
+	font-family: monospace;
+}
+
+.rd-trim-set-btn {
+	font-size: 0.85em;
+	padding: 0.25em 0.6em;
+	cursor: pointer;
+}
+
+.rd-trim-preview {
+	margin-top: 0.5em;
+	font-size: 0.85em;
+	color: #54595d;
+	font-style: italic;
+}
+
 /* Raw YAML toggle */
 .release-raw-yaml {
 	margin-top: 2em;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -313,6 +313,26 @@
 	font-style: italic;
 }
 
+/* Preview status */
+.rd-preview-status {
+	margin: 0.75em 0;
+	padding: 0.5em 0.75em;
+	font-size: 0.9em;
+	color: #54595d;
+	background: #f8f9fa;
+	border-radius: 3px;
+}
+
+/* Preserve original checkbox */
+.rd-preserve-label {
+	display: flex;
+	align-items: center;
+	gap: 0.4em;
+	font-size: 0.9em;
+	color: #54595d;
+	cursor: pointer;
+}
+
 /* More settings (collapsed) */
 .rd-more-settings {
 	margin: 1em 0;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.css
@@ -313,6 +313,17 @@
 	font-style: italic;
 }
 
+/* More settings (collapsed) */
+.rd-more-settings {
+	margin: 1em 0;
+	font-size: 0.9em;
+}
+
+.rd-more-settings summary {
+	cursor: pointer;
+	color: #72777d;
+}
+
 /* Raw YAML toggle */
 .release-raw-yaml {
 	margin-top: 2em;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -605,6 +605,10 @@
 				if ( content.trim_end_seconds != null ) {
 					finalizeBody.trim_end_seconds = content.trim_end_seconds;
 				}
+				var preserveCheckbox = el( 'rd-preserve-original' );
+				if ( preserveCheckbox && preserveCheckbox.checked ) {
+					finalizeBody.preserve_original = true;
+				}
 				body = JSON.stringify( finalizeBody );
 			}
 
@@ -1079,30 +1083,123 @@
 		var token = mw.config.get( 'wgUploadToken' );
 		var user = mw.config.get( 'wgUploadUser' );
 		var timestamp = mw.config.get( 'wgUploadTimestamp' );
+		var gatewayUrl = mw.config.get( 'wgIpfsGatewayUrl' ) || 'https://ipfs.delivery-kid.cryptograss.live';
 		var draftId = video.getAttribute( 'data-draft-id' );
 		var filename = video.getAttribute( 'data-filename' );
+		var previewStatus = el( 'rd-preview-status' );
+		var hlsInfo = el( 'rd-hls-info' );
 
-		if ( !deliveryKidUrl || !token || !draftId || !filename ) {
-			// Not logged in or missing config — hide the player
-			var container = el( 'rd-video-preview' );
-			if ( container ) {
-				container.style.display = 'none';
-			}
-			var trimControls = el( 'rd-trim-controls' );
-			if ( trimControls ) {
-				trimControls.style.display = 'none';
-			}
+		if ( !deliveryKidUrl || !draftId ) {
 			return;
 		}
 
-		var src = deliveryKidUrl + '/staging/drafts/' +
-			encodeURIComponent( draftId ) + '/' +
-			encodeURIComponent( filename ) +
-			'?token=' + encodeURIComponent( token ) +
-			'&user=' + encodeURIComponent( user ) +
-			'&timestamp=' + encodeURIComponent( timestamp );
+		function setVideoSrc( src ) {
+			video.src = src;
+			video.style.display = '';
+			if ( previewStatus ) {
+				previewStatus.style.display = 'none';
+			}
+		}
 
-		video.src = src;
+		function showPreviewStatus( msg ) {
+			if ( previewStatus ) {
+				previewStatus.textContent = msg;
+				previewStatus.style.display = '';
+			}
+			video.style.display = 'none';
+		}
+
+		function loadFromStaging() {
+			if ( !token || !filename ) {
+				return false;
+			}
+			var src = deliveryKidUrl + '/staging/drafts/' +
+				encodeURIComponent( draftId ) + '/' +
+				encodeURIComponent( filename ) +
+				'?token=' + encodeURIComponent( token ) +
+				'&user=' + encodeURIComponent( user ) +
+				'&timestamp=' + encodeURIComponent( timestamp );
+			setVideoSrc( src );
+			return true;
+		}
+
+		function pollForPreview() {
+			showPreviewStatus( '⏳ Preview is being transcoded...' );
+			if ( hlsInfo ) {
+				hlsInfo.textContent = 'AV1 HLS transcoding in progress. Preview will appear when ready.';
+			}
+
+			var headers = {};
+			if ( token ) {
+				headers[ 'X-Upload-Token' ] = token;
+				headers[ 'X-Upload-User' ] = user;
+				headers[ 'X-Upload-Timestamp' ] = String( timestamp );
+			}
+
+			var pollInterval = setInterval( function () {
+				fetch( deliveryKidUrl + '/draft-content/' + draftId, {
+					headers: headers
+				} ).then( function ( resp ) {
+					if ( !resp.ok ) {
+						return null;
+					}
+					return resp.json();
+				} ).then( function ( data ) {
+					if ( !data ) {
+						return;
+					}
+					if ( data.preview_status === 'ready' && data.preview_mp4_cid ) {
+						clearInterval( pollInterval );
+						setVideoSrc( gatewayUrl + '/ipfs/' + data.preview_mp4_cid );
+						if ( hlsInfo ) {
+							hlsInfo.textContent = 'AV1 HLS transcode complete. Ready to finalize.';
+						}
+					} else if ( data.preview_status === 'failed' ) {
+						clearInterval( pollInterval );
+						// Fall back to staging if available
+						if ( !loadFromStaging() ) {
+							showPreviewStatus( 'Preview transcoding failed.' );
+						}
+						if ( hlsInfo ) {
+							hlsInfo.textContent = 'Preview transcoding failed. Video will be transcoded on finalization.';
+						}
+					}
+				} ).catch( function () {
+					// Silently retry on network errors
+				} );
+			}, 10000 ); // Poll every 10 seconds
+		}
+
+		// Check delivery-kid for preview status
+		// The preview CID lives in delivery-kid's draft state, not the wiki YAML.
+		if ( token ) {
+			showPreviewStatus( '⏳ Checking preview...' );
+			var headers = {};
+			headers[ 'X-Upload-Token' ] = token;
+			headers[ 'X-Upload-User' ] = user;
+			headers[ 'X-Upload-Timestamp' ] = String( timestamp );
+
+			fetch( deliveryKidUrl + '/draft-content/' + draftId, {
+				headers: headers
+			} ).then( function ( resp ) {
+				return resp.ok ? resp.json() : null;
+			} ).then( function ( data ) {
+				if ( data && data.preview_status === 'ready' && data.preview_mp4_cid ) {
+					setVideoSrc( gatewayUrl + '/ipfs/' + data.preview_mp4_cid );
+					if ( hlsInfo ) {
+						hlsInfo.textContent = 'AV1 HLS transcode complete. Ready to finalize.';
+					}
+				} else if ( data && ( data.preview_status === 'pending' || data.preview_status === 'processing' ) ) {
+					pollForPreview();
+				} else {
+					loadFromStaging();
+				}
+			} ).catch( function () {
+				loadFromStaging();
+			} );
+		} else {
+			showPreviewStatus( 'Log in to preview video.' );
+		}
 
 		// "Set start" / "Set end" buttons grab current playback position
 		var setStartBtn = el( 'rd-trim-set-start' );

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -185,6 +185,19 @@
 					return s.length > 0;
 				} );
 			}
+			// Trim points
+			var trimStartEl = el( 'rd-trim-start' );
+			var trimEndEl = el( 'rd-trim-end' );
+			if ( trimStartEl && trimStartEl.value.trim() ) {
+				data.content.trim_start_seconds = parseTime( trimStartEl.value );
+			} else {
+				delete data.content.trim_start_seconds;
+			}
+			if ( trimEndEl && trimEndEl.value.trim() ) {
+				data.content.trim_end_seconds = parseTime( trimEndEl.value );
+			} else {
+				delete data.content.trim_end_seconds;
+			}
 		} else {
 			// Content fields (other, blue-railroad, etc.)
 			if ( !data.content ) {
@@ -341,6 +354,12 @@
 			( vidContent.performers || [] ).forEach( function ( p ) {
 				lines.push( '        - ' + quoteYamlValue( p ) );
 			} );
+			if ( vidContent.trim_start_seconds !== null && vidContent.trim_start_seconds !== undefined ) {
+				lines.push( '    trim_start_seconds: ' + vidContent.trim_start_seconds );
+			}
+			if ( vidContent.trim_end_seconds !== null && vidContent.trim_end_seconds !== undefined ) {
+				lines.push( '    trim_end_seconds: ' + vidContent.trim_end_seconds );
+			}
 
 			if ( data.files && data.files.length > 0 ) {
 				lines.push( 'files:' );
@@ -954,7 +973,66 @@
 		} );
 	}
 
-	// -- Video preview --
+	// -- Video preview & trim --
+
+	function formatTime( seconds ) {
+		if ( seconds === null || seconds === undefined || seconds === '' ) {
+			return '';
+		}
+		var s = parseFloat( seconds );
+		if ( isNaN( s ) ) {
+			return '';
+		}
+		var m = Math.floor( s / 60 );
+		var sec = s - m * 60;
+		return m + ':' + ( sec < 10 ? '0' : '' ) + sec.toFixed( 1 );
+	}
+
+	function parseTime( str ) {
+		if ( !str || !str.trim() ) {
+			return null;
+		}
+		str = str.trim();
+		// Accept m:ss.s or just seconds
+		var parts = str.split( ':' );
+		if ( parts.length === 2 ) {
+			return parseFloat( parts[ 0 ] ) * 60 + parseFloat( parts[ 1 ] );
+		}
+		var val = parseFloat( str );
+		return isNaN( val ) ? null : val;
+	}
+
+	function updateTrimPreview() {
+		var preview = el( 'rd-trim-preview' );
+		if ( !preview ) {
+			return;
+		}
+		var video = el( 'rd-video-player' );
+		var startInput = el( 'rd-trim-start' );
+		var endInput = el( 'rd-trim-end' );
+		if ( !startInput || !endInput ) {
+			return;
+		}
+
+		var start = parseTime( startInput.value );
+		var end = parseTime( endInput.value );
+		var duration = video ? video.duration : null;
+
+		var parts = [];
+		if ( start !== null && start > 0 ) {
+			parts.push( 'trimming first ' + formatTime( start ) );
+		}
+		if ( end !== null && duration && end < duration ) {
+			parts.push( 'trimming last ' + formatTime( duration - end ) );
+		}
+		if ( start !== null && end !== null ) {
+			var outputDuration = end - start;
+			if ( outputDuration > 0 ) {
+				parts.push( 'output duration: ' + formatTime( outputDuration ) );
+			}
+		}
+		preview.textContent = parts.length > 0 ? parts.join( ' · ' ) : '';
+	}
 
 	function initVideoPreview() {
 		var video = el( 'rd-video-player' );
@@ -975,6 +1053,10 @@
 			if ( container ) {
 				container.style.display = 'none';
 			}
+			var trimControls = el( 'rd-trim-controls' );
+			if ( trimControls ) {
+				trimControls.style.display = 'none';
+			}
 			return;
 		}
 
@@ -986,6 +1068,35 @@
 			'&timestamp=' + encodeURIComponent( timestamp );
 
 		video.src = src;
+
+		// "Set start" / "Set end" buttons grab current playback position
+		var setStartBtn = el( 'rd-trim-set-start' );
+		var setEndBtn = el( 'rd-trim-set-end' );
+		var startInput = el( 'rd-trim-start' );
+		var endInput = el( 'rd-trim-end' );
+
+		if ( setStartBtn && startInput ) {
+			setStartBtn.addEventListener( 'click', function () {
+				startInput.value = formatTime( video.currentTime );
+				updateTrimPreview();
+			} );
+		}
+		if ( setEndBtn && endInput ) {
+			setEndBtn.addEventListener( 'click', function () {
+				endInput.value = formatTime( video.currentTime );
+				updateTrimPreview();
+			} );
+		}
+		if ( startInput ) {
+			startInput.addEventListener( 'input', updateTrimPreview );
+		}
+		if ( endInput ) {
+			endInput.addEventListener( 'input', updateTrimPreview );
+		}
+
+		// Update preview once video metadata is loaded (to know total duration)
+		video.addEventListener( 'loadedmetadata', updateTrimPreview );
+		updateTrimPreview();
 	}
 
 	// -- Init --

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -591,14 +591,21 @@
 				}
 
 				endpoint = '/draft-content/' + draftId + '/finalize';
-				body = JSON.stringify( {
+				var finalizeBody = {
 					title: content.title || null,
 					description: content.description || null,
 					file_type: content.file_type || null,
 					subsequent_to: content.subsequent_to || null,
 					transcoding_strategy: 'auto',
 					metadata: {}
-				} );
+				};
+				if ( content.trim_start_seconds != null ) {
+					finalizeBody.trim_start_seconds = content.trim_start_seconds;
+				}
+				if ( content.trim_end_seconds != null ) {
+					finalizeBody.trim_end_seconds = content.trim_end_seconds;
+				}
+				body = JSON.stringify( finalizeBody );
 			}
 
 			finalizeBtn.disabled = true;

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -910,7 +910,7 @@
 			}
 		} );
 
-		// Date picker → estimate block number
+		// Date picker → look up exact block via Etherscan API
 		if ( dateInput ) {
 			dateInput.addEventListener( 'change', function () {
 				var dateStr = dateInput.value;
@@ -918,11 +918,30 @@
 					return;
 				}
 				var ts = Math.floor( new Date( dateStr + 'T12:00:00Z' ).getTime() / 1000 );
+
+				// Show local estimate immediately while API call is in flight
 				var estimated = timestampToBlock( ts );
 				if ( estimated > 0 ) {
 					bhInput.value = estimated;
 					updateBlockDate( estimated );
 				}
+
+				// Fetch exact block from Etherscan
+				fetch( 'https://api.etherscan.io/api?module=block&action=getblocknobytime' +
+					'&timestamp=' + ts + '&closest=before' )
+					.then( function ( r ) { return r.json(); } )
+					.then( function ( resp ) {
+						if ( resp.status === '1' && resp.result ) {
+							var block = parseInt( resp.result, 10 );
+							if ( block > 0 ) {
+								bhInput.value = block;
+								updateBlockDate( block );
+							}
+						}
+					} )
+					.catch( function () {
+						// Local estimate already in place, nothing to do
+					} );
 			} );
 		}
 

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -986,6 +986,8 @@
 		if ( !dateLabel ) {
 			return;
 		}
+
+		// Show local estimate immediately
 		var estimatedTs = blockToTimestamp( blockNumber );
 		var date = new Date( estimatedTs * 1000 );
 		dateLabel.textContent = '≈ ' + date.toLocaleDateString( 'en-US', {
@@ -993,6 +995,34 @@
 			month: 'long',
 			day: 'numeric'
 		} );
+
+		// Fetch actual block timestamp via public Ethereum RPC
+		var hexBlock = '0x' + blockNumber.toString( 16 );
+		fetch( 'https://ethereum-rpc.publicnode.com', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify( {
+				jsonrpc: '2.0',
+				method: 'eth_getBlockByNumber',
+				params: [ hexBlock, false ],
+				id: 1
+			} )
+		} )
+			.then( function ( r ) { return r.json(); } )
+			.then( function ( resp ) {
+				if ( resp.result && resp.result.timestamp ) {
+					var ts = parseInt( resp.result.timestamp, 16 );
+					var exactDate = new Date( ts * 1000 );
+					dateLabel.textContent = exactDate.toLocaleDateString( 'en-US', {
+						year: 'numeric',
+						month: 'long',
+						day: 'numeric'
+					} );
+				}
+			} )
+			.catch( function () {
+				// Local estimate already shown
+			} );
 	}
 
 	// -- Video preview & trim --

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -910,7 +910,7 @@
 			}
 		} );
 
-		// Date picker → look up exact block via Etherscan API
+		// Date picker → estimate block from date (local formula, day-level precision)
 		if ( dateInput ) {
 			dateInput.addEventListener( 'change', function () {
 				var dateStr = dateInput.value;
@@ -918,30 +918,11 @@
 					return;
 				}
 				var ts = Math.floor( new Date( dateStr + 'T12:00:00Z' ).getTime() / 1000 );
-
-				// Show local estimate immediately while API call is in flight
 				var estimated = timestampToBlock( ts );
 				if ( estimated > 0 ) {
 					bhInput.value = estimated;
 					updateBlockDate( estimated );
 				}
-
-				// Fetch exact block from Etherscan
-				fetch( 'https://api.etherscan.io/api?module=block&action=getblocknobytime' +
-					'&timestamp=' + ts + '&closest=before' )
-					.then( function ( r ) { return r.json(); } )
-					.then( function ( resp ) {
-						if ( resp.status === '1' && resp.result ) {
-							var block = parseInt( resp.result, 10 );
-							if ( block > 0 ) {
-								bhInput.value = block;
-								updateBlockDate( block );
-							}
-						}
-					} )
-					.catch( function () {
-						// Local estimate already in place, nothing to do
-					} );
 			} );
 		}
 
@@ -987,14 +968,7 @@
 			return;
 		}
 
-		// Show local estimate immediately
-		var estimatedTs = blockToTimestamp( blockNumber );
-		var date = new Date( estimatedTs * 1000 );
-		dateLabel.textContent = '≈ ' + date.toLocaleDateString( 'en-US', {
-			year: 'numeric',
-			month: 'long',
-			day: 'numeric'
-		} );
+		dateLabel.textContent = '⏳';
 
 		// Fetch actual block timestamp via public Ethereum RPC
 		var hexBlock = '0x' + blockNumber.toString( 16 );
@@ -1018,10 +992,12 @@
 						month: 'long',
 						day: 'numeric'
 					} );
+				} else {
+					dateLabel.textContent = '';
 				}
 			} )
 			.catch( function () {
-				// Local estimate already shown
+				dateLabel.textContent = '';
 			} );
 	}
 

--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -382,6 +382,9 @@
 					if ( f.size_bytes ) {
 						lines.push( '        size_bytes: ' + f.size_bytes );
 					}
+					if ( f.creation_time ) {
+						lines.push( '        creation_time: ' + quoteYamlValue( f.creation_time ) );
+					}
 				} );
 			}
 		} else if ( draftType === 'blue-railroad' ) {
@@ -1101,12 +1104,34 @@
 
 	// -- Init --
 
+	function initCreationTimeFallback() {
+		// If the date field is empty and a video file has creation_time
+		// metadata (from the camera/phone), pre-fill the date picker.
+		var dateInput = el( 'rd-date-input' );
+		var bhInput = el( 'rd-blockheight' );
+		if ( !dateInput || dateInput.value || ( bhInput && bhInput.value ) ) {
+			return;
+		}
+		var files = ( draftData && draftData.files ) || [];
+		for ( var i = 0; i < files.length; i++ ) {
+			if ( files[ i ].creation_time ) {
+				var dateStr = files[ i ].creation_time.substring( 0, 10 );
+				if ( /^\d{4}-\d{2}-\d{2}$/.test( dateStr ) ) {
+					dateInput.value = dateStr;
+					dateInput.dispatchEvent( new Event( 'change' ) );
+					break;
+				}
+			}
+		}
+	}
+
 	function init() {
 		initTrackDragReorder();
 		initSaveButton();
 		initFinalizeButton();
 		initBlockheightConverter();
 		initVideoPreview();
+		initCreationTimeFallback();
 	}
 
 	mw.loader.using( [ 'mediawiki.util', 'mediawiki.api' ] ).then( init );

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -506,6 +506,63 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 							'data-filename' => $f['original_filename'] ?? '',
 						] )
 					);
+
+					// Trim controls — set start/end from current playback position
+					$trimStart = $data['content']['trim_start_seconds'] ?? '';
+					$trimEnd = $data['content']['trim_end_seconds'] ?? '';
+					$disabled = ( $status !== 'draft' ) ? [ 'disabled' => true ] : [];
+
+					$html .= Html::openElement( 'div', [
+						'class' => 'rd-trim-controls',
+						'id' => 'rd-trim-controls',
+					] );
+					$html .= Html::element( 'h4', [], 'Trim' );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-row' ] );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
+					$html .= Html::element( 'label', [ 'for' => 'rd-trim-start' ], 'Start' );
+					$html .= Html::element( 'input', array_merge( [
+						'type' => 'text',
+						'id' => 'rd-trim-start',
+						'class' => 'rd-trim-input',
+						'value' => $trimStart,
+						'placeholder' => '0:00',
+						'size' => 8,
+					], $disabled ) );
+					$html .= Html::element( 'button', array_merge( [
+						'type' => 'button',
+						'id' => 'rd-trim-set-start',
+						'class' => 'rd-trim-set-btn',
+					], $disabled ), 'Set start' );
+					$html .= Html::closeElement( 'div' );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
+					$html .= Html::element( 'label', [ 'for' => 'rd-trim-end' ], 'End' );
+					$html .= Html::element( 'input', array_merge( [
+						'type' => 'text',
+						'id' => 'rd-trim-end',
+						'class' => 'rd-trim-input',
+						'value' => $trimEnd,
+						'placeholder' => '0:00',
+						'size' => 8,
+					], $disabled ) );
+					$html .= Html::element( 'button', array_merge( [
+						'type' => 'button',
+						'id' => 'rd-trim-set-end',
+						'class' => 'rd-trim-set-btn',
+					], $disabled ), 'Set end' );
+					$html .= Html::closeElement( 'div' );
+
+					$html .= Html::closeElement( 'div' ); // .rd-trim-row
+
+					$html .= Html::element( 'div', [
+						'class' => 'rd-trim-preview',
+						'id' => 'rd-trim-preview',
+					] );
+
+					$html .= Html::closeElement( 'div' ); // .rd-trim-controls
+
 					break; // Only embed first video
 				}
 			}

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -492,23 +492,34 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 
 			$html .= Html::closeElement( 'table' );
 
-			// Embed video player for preview (JS sets src with auth query params)
+			// Embed video player for preview
+			// If preview HLS is ready, JS will use the IPFS CID.
+			// If still processing, JS will show a status message and poll.
+			// Fallback: stream original from staging (large files).
 			$draftId = $data['draft_id'] ?? '';
 			foreach ( $files as $f ) {
 				if ( ( $f['media_type'] ?? '' ) === 'video' && $draftId ) {
-					$html .= Html::rawElement( 'div', [
+					$html .= Html::openElement( 'div', [
 						'class' => 'rd-video-preview',
 						'id' => 'rd-video-preview',
-					],
-						Html::element( 'video', [
-							'id' => 'rd-video-player',
-							'class' => 'rd-video-player',
-							'controls' => true,
-							'preload' => 'metadata',
-							'data-draft-id' => $draftId,
-							'data-filename' => $f['original_filename'] ?? '',
-						] )
-					);
+					] );
+
+					// Preview status message (shown/hidden by JS)
+					$html .= Html::element( 'div', [
+						'id' => 'rd-preview-status',
+						'class' => 'rd-preview-status',
+					], '' );
+
+					$html .= Html::element( 'video', [
+						'id' => 'rd-video-player',
+						'class' => 'rd-video-player',
+						'controls' => true,
+						'preload' => 'metadata',
+						'data-draft-id' => $draftId,
+						'data-filename' => $f['original_filename'] ?? '',
+					] );
+
+					$html .= Html::closeElement( 'div' );
 
 					// Trim controls — set start/end from current playback position
 					$trimStart = $data['content']['trim_start_seconds'] ?? '';
@@ -570,8 +581,8 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 				}
 			}
 
-			$html .= Html::rawElement( 'p', [ 'class' => 'uc-hls-info' ],
-				'Video will be transcoded to AV1 HLS (royalty-free) automatically on finalization.' );
+			$html .= Html::rawElement( 'p', [ 'class' => 'uc-hls-info', 'id' => 'rd-hls-info' ],
+				'Video will be transcoded to AV1 HLS (royalty-free).' );
 		}
 
 		$html .= Html::closeElement( 'div' );
@@ -639,6 +650,18 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 			'id' => 'rd-save-btn',
 			'class' => 'cdx-button cdx-button--action-progressive',
 		], 'Save Draft' );
+
+		// Preserve original checkbox
+		$html .= Html::openElement( 'label', [
+			'class' => 'rd-preserve-label',
+			'for' => 'rd-preserve-original',
+		] );
+		$html .= Html::element( 'input', [
+			'type' => 'checkbox',
+			'id' => 'rd-preserve-original',
+		] );
+		$html .= ' Keep original file';
+		$html .= Html::closeElement( 'label' );
 
 		$html .= Html::element( 'button', [
 			'type' => 'button',

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -452,11 +452,14 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 		], $content['description'] ?? '' );
 		$html .= Html::closeElement( 'div' );
 
-		// File type override
+		$html .= Html::closeElement( 'div' );
+
+		// More settings (collapsed)
+		$html .= Html::openElement( 'details', [ 'class' => 'rd-more-settings' ] );
+		$html .= Html::element( 'summary', [], 'More settings' );
 		$html .= $this->renderField( 'rd-content-file-type', 'File type override',
 			$content['file_type'] ?? '', 'text', $disabled );
-
-		$html .= Html::closeElement( 'div' );
+		$html .= Html::closeElement( 'details' );
 
 		// File info table — media_type values ("audio", "video", "image", "other")
 		// are set by delivery-kid's analyze.detect_media_type() during upload,
@@ -579,12 +582,22 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 		$blockheight = $data['blockheight'] ?? '';
 
 		$html = Html::openElement( 'div', [ 'class' => 'rd-blockheight-section' ] );
-		$html .= Html::element( 'h3', [], 'Temporal Reference' );
+		$html .= Html::element( 'h3', [], 'When did this happen?' );
 
 		$html .= Html::openElement( 'div', [ 'class' => 'uc-field' ] );
-		$html .= Html::element( 'label', [ 'for' => 'rd-blockheight' ], 'Ethereum Block Height' );
+		$html .= Html::element( 'label', [ 'for' => 'rd-date-input' ],
+			'Approximately when did the events depicted go down?' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-date-converter' ] );
+		$html .= Html::element( 'input', [
+			'type' => 'date',
+			'id' => 'rd-date-input',
+			'class' => 'cdx-text-input__input rd-date-input',
+		] );
+		$html .= Html::closeElement( 'div' );
 
 		$html .= Html::openElement( 'div', [ 'class' => 'rd-blockheight-row' ] );
+		$html .= Html::element( 'label', [ 'for' => 'rd-blockheight' ], 'Or enter an Ethereum block height:' );
 		$html .= Html::element( 'input', [
 			'type' => 'text',
 			'id' => 'rd-blockheight',
@@ -600,28 +613,14 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 		$html .= Html::element( 'span', [ 'id' => 'rd-blockheight-date', 'class' => 'rd-blockheight-date' ], '' );
 		$html .= Html::closeElement( 'div' );
 
-		$html .= Html::openElement( 'div', [ 'class' => 'rd-date-converter' ] );
-		$html .= Html::element( 'label', [ 'for' => 'rd-date-input' ], 'Or pick a date:' );
-		$html .= Html::element( 'input', [
-			'type' => 'date',
-			'id' => 'rd-date-input',
-			'class' => 'cdx-text-input__input rd-date-input',
-		] );
-		$html .= Html::closeElement( 'div' );
-
-		// Upload blockheight — auto-captured at upload time, read-only
+		// Upload blockheight — auto-captured server-side, preserved in YAML
 		$uploadBlockheight = $data['upload_blockheight'] ?? null;
 		if ( $uploadBlockheight ) {
-			$html .= Html::openElement( 'div', [ 'class' => 'uc-field' ] );
-			$html .= Html::element( 'label', [], 'Upload block height' );
-			$html .= Html::element( 'span', [ 'class' => 'rd-upload-blockheight' ],
-				(string)$uploadBlockheight );
 			$html .= Html::element( 'input', [
 				'type' => 'hidden',
 				'id' => 'rd-upload-blockheight',
 				'value' => $uploadBlockheight,
 			] );
-			$html .= Html::closeElement( 'div' );
 		}
 
 		$html .= Html::closeElement( 'div' );

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -389,18 +389,95 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 
 			$html .= Html::closeElement( 'table' );
 
-			// Video transcoding info
-			$hasVideo = false;
+			// Embed video player for preview (same logic as renderVideoForm)
+			$draftId = $data['draft_id'] ?? '';
 			foreach ( $files as $f ) {
-				if ( ( $f['media_type'] ?? '' ) === 'video' ) {
-					$hasVideo = true;
-					break;
+				if ( ( $f['media_type'] ?? '' ) === 'video' && $draftId ) {
+					$html .= Html::openElement( 'div', [
+						'class' => 'rd-video-preview',
+						'id' => 'rd-video-preview',
+					] );
+
+					$html .= Html::element( 'div', [
+						'id' => 'rd-preview-status',
+						'class' => 'rd-preview-status',
+					], '' );
+
+					$html .= Html::element( 'video', [
+						'id' => 'rd-video-player',
+						'class' => 'rd-video-player',
+						'controls' => true,
+						'preload' => 'metadata',
+						'data-draft-id' => $draftId,
+						'data-filename' => $f['original_filename'] ?? '',
+					] );
+
+					$html .= Html::closeElement( 'div' );
+
+					// Trim controls
+					$trimStart = $data['content']['trim_start_seconds'] ?? '';
+					$trimEnd = $data['content']['trim_end_seconds'] ?? '';
+					$trimDisabled = ( $status !== 'draft' ) ? [ 'disabled' => true ] : [];
+
+					$html .= Html::openElement( 'div', [
+						'class' => 'rd-trim-controls',
+						'id' => 'rd-trim-controls',
+					] );
+					$html .= Html::element( 'h4', [], 'Trim' );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-row' ] );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
+					$html .= Html::element( 'label', [ 'for' => 'rd-trim-start' ], 'Start' );
+					$html .= Html::element( 'input', array_merge( [
+						'type' => 'number',
+						'id' => 'rd-trim-start',
+						'class' => 'cdx-text-input__input rd-trim-input',
+						'step' => '0.1',
+						'min' => '0',
+						'value' => $trimStart,
+						'placeholder' => '0.0',
+					], $trimDisabled ) );
+					$html .= Html::element( 'button', array_merge( [
+						'type' => 'button',
+						'id' => 'rd-trim-set-start',
+						'class' => 'cdx-button rd-trim-set-btn',
+					], $trimDisabled ), 'Set to current' );
+					$html .= Html::closeElement( 'div' );
+
+					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
+					$html .= Html::element( 'label', [ 'for' => 'rd-trim-end' ], 'End' );
+					$html .= Html::element( 'input', array_merge( [
+						'type' => 'number',
+						'id' => 'rd-trim-end',
+						'class' => 'cdx-text-input__input rd-trim-input',
+						'step' => '0.1',
+						'min' => '0',
+						'value' => $trimEnd,
+						'placeholder' => '0.0',
+					], $trimDisabled ) );
+					$html .= Html::element( 'button', array_merge( [
+						'type' => 'button',
+						'id' => 'rd-trim-set-end',
+						'class' => 'cdx-button rd-trim-set-btn',
+					], $trimDisabled ), 'Set to current' );
+					$html .= Html::closeElement( 'div' );
+
+					$html .= Html::closeElement( 'div' ); // rd-trim-row
+
+					$html .= Html::element( 'div', [
+						'id' => 'rd-trim-preview',
+						'class' => 'rd-trim-preview',
+					], '' );
+
+					$html .= Html::closeElement( 'div' ); // rd-trim-controls
+
+					break; // Only embed first video
 				}
 			}
-			if ( $hasVideo ) {
-				$html .= Html::rawElement( 'p', [ 'class' => 'uc-hls-info' ],
-					'Video will be transcoded to AV1 HLS (royalty-free) automatically on finalization.' );
-			}
+
+			$html .= Html::rawElement( 'p', [ 'class' => 'uc-hls-info', 'id' => 'rd-hls-info' ],
+				'Video will be transcoded to AV1 HLS (royalty-free).' );
 		}
 
 		$html .= Html::closeElement( 'div' );


### PR DESCRIPTION
## Summary
- Rewrite `initVideoPreview()` to load 480p MP4 preview from IPFS instead of streaming full original from staging
- Polls delivery-kid every 10s while transcoding is in progress
- Falls back to staging URL if no preview available
- Add "Keep original file" checkbox (sends `preserve_original` in finalize request)
- Add preview status div and CSS

## Test plan
- [ ] Visit ReleaseDraft for video draft → preview loads from IPFS or staging fallback
- [ ] New video upload → "Preview is being transcoded..." → preview appears after Coconut finishes
- [ ] "Keep original file" checkbox → original preserved on storage box
- [ ] Not logged in → shows "Log in to preview video."