### PR TITLE
Fix 500 on Special:FormEdit pages (PageForms hook)

### DIFF
--- a/extensions/PickiPediaReleases/src/DeliveryKidUploadInput.php
+++ b/extensions/PickiPediaReleases/src/DeliveryKidUploadInput.php
@@ -32,7 +32,7 @@ class DeliveryKidUploadInput extends PFFormInput {
 	/**
 	 * @return string[]
 	 */
-	public static function getResourceModuleNames(): array {
+	public function getResourceModuleNames(): array {
 		return [ 'ext.pickipediaReleases.deliveryKidInput' ];
 	}
 

--- a/extensions/PickiPediaReleases/src/Hooks.php
+++ b/extensions/PickiPediaReleases/src/Hooks.php
@@ -90,7 +90,7 @@ class Hooks implements LoadExtensionSchemaUpdatesHook, BeforePageDisplayHook {
 	 *
 	 * @param \PFFormPrinter &$formPrinter
 	 */
-	public function onPageFormsFormPrinterSetup( &$formPrinter ): void {
+	public function onPageForms__FormPrinterSetup( &$formPrinter ): void {
 		$formPrinter->registerInputType(
 			'MediaWiki\\Extension\\PickiPediaReleases\\DeliveryKidUploadInput'
 		);


### PR DESCRIPTION
## Summary
- Fix hook method name: `onPageFormsFormPrinterSetup` → `onPageForms__FormPrinterSetup` (MW expects double underscores for namespaced hook names like `PageForms::FormPrinterSetup`)
- Fix `getResourceModuleNames()`: remove `static` keyword since parent `PFFormInput` declares it non-static (PHP 8 fatal)

These two bugs cause a 500 error on every `Special:FormEdit` page (Guitar, etc).

## Test plan
- [ ] Visit https://pickipedia.xyz/wiki/Special:FormEdit/Guitar — should render the form instead of 500