### PR TITLE
Share video preview and trim across all draft types

### DIFF
--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -185,19 +185,6 @@
 					return s.length > 0;
 				} );
 			}
-			// Trim points
-			var trimStartEl = el( 'rd-trim-start' );
-			var trimEndEl = el( 'rd-trim-end' );
-			if ( trimStartEl && trimStartEl.value.trim() ) {
-				data.content.trim_start_seconds = parseTime( trimStartEl.value );
-			} else {
-				delete data.content.trim_start_seconds;
-			}
-			if ( trimEndEl && trimEndEl.value.trim() ) {
-				data.content.trim_end_seconds = parseTime( trimEndEl.value );
-			} else {
-				delete data.content.trim_end_seconds;
-			}
 		} else {
 			// Content fields (other, blue-railroad, etc.)
 			if ( !data.content ) {
@@ -219,6 +206,22 @@
 			}
 			if ( contentSubsequentToEl ) {
 				data.content.subsequent_to = contentSubsequentToEl.value;
+			}
+		}
+
+		// Trim points (shared across video and content forms)
+		if ( data.content ) {
+			var trimStartEl = el( 'rd-trim-start' );
+			var trimEndEl = el( 'rd-trim-end' );
+			if ( trimStartEl && trimStartEl.value.trim() ) {
+				data.content.trim_start_seconds = parseTime( trimStartEl.value );
+			} else {
+				delete data.content.trim_start_seconds;
+			}
+			if ( trimEndEl && trimEndEl.value.trim() ) {
+				data.content.trim_end_seconds = parseTime( trimEndEl.value );
+			} else {
+				delete data.content.trim_end_seconds;
 			}
 		}
 

--- a/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseDraftContentHandler.php
@@ -389,17 +389,22 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 
 			$html .= Html::closeElement( 'table' );
 
-			// Video transcoding info
+			// Video preview, trim controls
+			$draftId = $data['draft_id'] ?? '';
 			$hasVideo = false;
 			foreach ( $files as $f ) {
 				if ( ( $f['media_type'] ?? '' ) === 'video' ) {
 					$hasVideo = true;
+					if ( $draftId ) {
+						$html .= $this->renderVideoPreviewAndTrim( $f, $draftId, $data, $status );
+					}
 					break;
 				}
 			}
+
 			if ( $hasVideo ) {
-				$html .= Html::rawElement( 'p', [ 'class' => 'uc-hls-info' ],
-					'Video will be transcoded to AV1 HLS (royalty-free) automatically on finalization.' );
+				$html .= Html::rawElement( 'p', [ 'class' => 'uc-hls-info', 'id' => 'rd-hls-info' ],
+					'Video will be transcoded to AV1 HLS (royalty-free).' );
 			}
 		}
 
@@ -492,92 +497,12 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 
 			$html .= Html::closeElement( 'table' );
 
-			// Embed video player for preview
-			// If preview HLS is ready, JS will use the IPFS CID.
-			// If still processing, JS will show a status message and poll.
-			// Fallback: stream original from staging (large files).
+			// Video preview, trim controls
 			$draftId = $data['draft_id'] ?? '';
 			foreach ( $files as $f ) {
 				if ( ( $f['media_type'] ?? '' ) === 'video' && $draftId ) {
-					$html .= Html::openElement( 'div', [
-						'class' => 'rd-video-preview',
-						'id' => 'rd-video-preview',
-					] );
-
-					// Preview status message (shown/hidden by JS)
-					$html .= Html::element( 'div', [
-						'id' => 'rd-preview-status',
-						'class' => 'rd-preview-status',
-					], '' );
-
-					$html .= Html::element( 'video', [
-						'id' => 'rd-video-player',
-						'class' => 'rd-video-player',
-						'controls' => true,
-						'preload' => 'metadata',
-						'data-draft-id' => $draftId,
-						'data-filename' => $f['original_filename'] ?? '',
-					] );
-
-					$html .= Html::closeElement( 'div' );
-
-					// Trim controls — set start/end from current playback position
-					$trimStart = $data['content']['trim_start_seconds'] ?? '';
-					$trimEnd = $data['content']['trim_end_seconds'] ?? '';
-					$disabled = ( $status !== 'draft' ) ? [ 'disabled' => true ] : [];
-
-					$html .= Html::openElement( 'div', [
-						'class' => 'rd-trim-controls',
-						'id' => 'rd-trim-controls',
-					] );
-					$html .= Html::element( 'h4', [], 'Trim' );
-
-					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-row' ] );
-
-					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
-					$html .= Html::element( 'label', [ 'for' => 'rd-trim-start' ], 'Start' );
-					$html .= Html::element( 'input', array_merge( [
-						'type' => 'text',
-						'id' => 'rd-trim-start',
-						'class' => 'rd-trim-input',
-						'value' => $trimStart,
-						'placeholder' => '0:00',
-						'size' => 8,
-					], $disabled ) );
-					$html .= Html::element( 'button', array_merge( [
-						'type' => 'button',
-						'id' => 'rd-trim-set-start',
-						'class' => 'rd-trim-set-btn',
-					], $disabled ), 'Set start' );
-					$html .= Html::closeElement( 'div' );
-
-					$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
-					$html .= Html::element( 'label', [ 'for' => 'rd-trim-end' ], 'End' );
-					$html .= Html::element( 'input', array_merge( [
-						'type' => 'text',
-						'id' => 'rd-trim-end',
-						'class' => 'rd-trim-input',
-						'value' => $trimEnd,
-						'placeholder' => '0:00',
-						'size' => 8,
-					], $disabled ) );
-					$html .= Html::element( 'button', array_merge( [
-						'type' => 'button',
-						'id' => 'rd-trim-set-end',
-						'class' => 'rd-trim-set-btn',
-					], $disabled ), 'Set end' );
-					$html .= Html::closeElement( 'div' );
-
-					$html .= Html::closeElement( 'div' ); // .rd-trim-row
-
-					$html .= Html::element( 'div', [
-						'class' => 'rd-trim-preview',
-						'id' => 'rd-trim-preview',
-					] );
-
-					$html .= Html::closeElement( 'div' ); // .rd-trim-controls
-
-					break; // Only embed first video
+					$html .= $this->renderVideoPreviewAndTrim( $f, $draftId, $data, $status );
+					break;
 				}
 			}
 
@@ -586,6 +511,94 @@ class ReleaseDraftContentHandler extends TextContentHandler {
 		}
 
 		$html .= Html::closeElement( 'div' );
+		return $html;
+	}
+
+	/**
+	 * Render video preview player, preview status, and trim controls.
+	 * Shared by renderGenericForm and renderVideoForm.
+	 */
+	private function renderVideoPreviewAndTrim(
+		array $file, string $draftId, array $data, string $status
+	): string {
+		$html = Html::openElement( 'div', [
+			'class' => 'rd-video-preview',
+			'id' => 'rd-video-preview',
+		] );
+
+		// Preview status message (shown/hidden by JS)
+		$html .= Html::element( 'div', [
+			'id' => 'rd-preview-status',
+			'class' => 'rd-preview-status',
+		], '' );
+
+		$html .= Html::element( 'video', [
+			'id' => 'rd-video-player',
+			'class' => 'rd-video-player',
+			'controls' => true,
+			'preload' => 'metadata',
+			'data-draft-id' => $draftId,
+			'data-filename' => $file['original_filename'] ?? '',
+		] );
+
+		$html .= Html::closeElement( 'div' );
+
+		// Trim controls
+		$trimStart = $data['content']['trim_start_seconds'] ?? '';
+		$trimEnd = $data['content']['trim_end_seconds'] ?? '';
+		$trimDisabled = ( $status !== 'draft' ) ? [ 'disabled' => true ] : [];
+
+		$html .= Html::openElement( 'div', [
+			'class' => 'rd-trim-controls',
+			'id' => 'rd-trim-controls',
+		] );
+		$html .= Html::element( 'h4', [], 'Trim' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-row' ] );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
+		$html .= Html::element( 'label', [ 'for' => 'rd-trim-start' ], 'Start' );
+		$html .= Html::element( 'input', array_merge( [
+			'type' => 'text',
+			'id' => 'rd-trim-start',
+			'class' => 'rd-trim-input',
+			'value' => $trimStart,
+			'placeholder' => '0:00',
+			'size' => 8,
+		], $trimDisabled ) );
+		$html .= Html::element( 'button', array_merge( [
+			'type' => 'button',
+			'id' => 'rd-trim-set-start',
+			'class' => 'rd-trim-set-btn',
+		], $trimDisabled ), 'Set start' );
+		$html .= Html::closeElement( 'div' );
+
+		$html .= Html::openElement( 'div', [ 'class' => 'rd-trim-field' ] );
+		$html .= Html::element( 'label', [ 'for' => 'rd-trim-end' ], 'End' );
+		$html .= Html::element( 'input', array_merge( [
+			'type' => 'text',
+			'id' => 'rd-trim-end',
+			'class' => 'rd-trim-input',
+			'value' => $trimEnd,
+			'placeholder' => '0:00',
+			'size' => 8,
+		], $trimDisabled ) );
+		$html .= Html::element( 'button', array_merge( [
+			'type' => 'button',
+			'id' => 'rd-trim-set-end',
+			'class' => 'rd-trim-set-btn',
+		], $trimDisabled ), 'Set end' );
+		$html .= Html::closeElement( 'div' );
+
+		$html .= Html::closeElement( 'div' ); // rd-trim-row
+
+		$html .= Html::element( 'div', [
+			'id' => 'rd-trim-preview',
+			'class' => 'rd-trim-preview',
+		], '' );
+
+		$html .= Html::closeElement( 'div' ); // rd-trim-controls
+
 		return $html;
 	}
 


### PR DESCRIPTION
## Summary

- Extracts `renderVideoPreviewAndTrim()` as a shared PHP method used by both `renderGenericForm` (type:other) and `renderVideoForm` (type:video)
- Moves trim serialization out of the video-only JS save block so trim values are saved for all draft types that contain video files
- Adds `id='rd-hls-info'` to the HLS info paragraph for JS updates

Previously, uploading video through Special:UploadContent (which creates `type: other` drafts) would show no video preview or trim controls — only `type: video` drafts had them. Now both form types get the same preview player, trim controls, and trim serialization.

This is a clean rebase onto production (replacing PR #68 which had conflicts).

## Test plan

- [ ] Visit a `type: other` ReleaseDraft with a video file — video preview and trim controls should appear
- [ ] Visit a `type: video` ReleaseDraft — same behavior as before (no regression)
- [ ] Set trim points and save — trim values should persist in YAML for both draft types
- [ ] Finalize with trim values — trim_start_seconds/trim_end_seconds sent to delivery-kid