### PR TITLE
Group Special:Releases by type with SMW properties

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -214,7 +214,9 @@ wfLoadExtension( 'MediaUploader' );
 $wgMediaUploaderConfig = [
     'tutorial' => [ 'enabled' => false ],
 ];
-$wgUploadNavigationUrl = '/wiki/Special:MediaUploader';
+# MediaUploader works but Caddy drops POST body on chunked uploads
+# See: https://github.com/cryptograss/maybelle-config/issues/79
+# $wgUploadNavigationUrl = '/wiki/Special:MediaUploader';
 $wgMSU_checkAutoCat = true;
 $wgMSU_imgParams = '400px';
 $wgMSU_uploadsize = '1024mb';

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -214,9 +214,7 @@ wfLoadExtension( 'MediaUploader' );
 $wgMediaUploaderConfig = [
     'tutorial' => [ 'enabled' => false ],
 ];
-# MediaUploader works but Caddy drops POST body on chunked uploads
-# See: https://github.com/cryptograss/maybelle-config/issues/79
-# $wgUploadNavigationUrl = '/wiki/Special:MediaUploader';
+$wgUploadNavigationUrl = '/wiki/Special:MediaUploader';
 $wgMSU_checkAutoCat = true;
 $wgMSU_imgParams = '400px';
 $wgMSU_uploadsize = '1024mb';

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -214,8 +214,7 @@ wfLoadExtension( 'MediaUploader' );
 $wgMediaUploaderConfig = [
     'tutorial' => [ 'enabled' => false ],
 ];
-# Disabled until Caddy upload bug resolved (pickipedia#71)
-# $wgUploadNavigationUrl = '/wiki/Special:MediaUploader';
+$wgUploadNavigationUrl = '/wiki/Special:MediaUploader';
 $wgMSU_checkAutoCat = true;
 $wgMSU_imgParams = '400px';
 $wgMSU_uploadsize = '1024mb';

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -214,7 +214,8 @@ wfLoadExtension( 'MediaUploader' );
 $wgMediaUploaderConfig = [
     'tutorial' => [ 'enabled' => false ],
 ];
-$wgUploadNavigationUrl = '/wiki/Special:MediaUploader';
+# Disabled until Caddy upload bug resolved (pickipedia#71)
+# $wgUploadNavigationUrl = '/wiki/Special:MediaUploader';
 $wgMSU_checkAutoCat = true;
 $wgMSU_imgParams = '400px';
 $wgMSU_uploadsize = '1024mb';

--- a/extensions/PickiPediaReleases/src/ReleaseContent.php
+++ b/extensions/PickiPediaReleases/src/ReleaseContent.php
@@ -112,6 +112,16 @@ class ReleaseContent extends AbstractContent {
 	}
 
 	/**
+	 * Get release type (video, record, blue-railroad, other)
+	 *
+	 * @return string|null
+	 */
+	public function getReleaseType(): ?string {
+		$data = $this->getData();
+		return $data['release_type'] ?? null;
+	}
+
+	/**
 	 * Get file type (MIME type)
 	 *
 	 * @return string|null

--- a/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
@@ -134,7 +134,113 @@ YAML;
 			if ( !empty( $data['pinned_on'] ) ) {
 				$output->addCategory( 'Pinned_Releases' );
 			}
+
+			// Add category based on release type
+			$releaseType = $data['release_type'] ?? null;
+			if ( $releaseType ) {
+				$typeCategoryMap = [
+					'video' => 'Video_Releases',
+					'record' => 'Record_Releases',
+					'blue-railroad' => 'Blue_Railroad_Releases',
+					'other' => 'Other_Releases',
+				];
+				if ( isset( $typeCategoryMap[$releaseType] ) ) {
+					$output->addCategory( $typeCategoryMap[$releaseType] );
+				}
+			}
 		}
+
+		// Emit Semantic MediaWiki properties if SMW is available
+		if ( $pageRef && class_exists( \SMW\DIProperty::class ) ) {
+			$this->setSemanticProperties( $output, $cid, $data, $pageRef );
+		}
+	}
+
+	/**
+	 * Emit Semantic MediaWiki properties for this Release page.
+	 *
+	 * @param ParserOutput $output
+	 * @param string|null $cid
+	 * @param array $data
+	 * @param mixed $pageRef
+	 */
+	private function setSemanticProperties(
+		ParserOutput $output,
+		?string $cid,
+		array $data,
+		$pageRef
+	): void {
+		$title = \MediaWiki\MediaWikiServices::getInstance()
+			->getTitleFactory()
+			->makeTitle( $pageRef->getNamespace(), $pageRef->getDBkey() );
+
+		$subject = \SMW\DIWikiPage::newFromTitle( $title );
+		$semanticData = new \SMW\SemanticData( $subject );
+
+		if ( $cid ) {
+			$normalizedCid = str_starts_with( $cid, 'Bafy' ) ? strtolower( $cid ) : $cid;
+			$semanticData->addPropertyObjectValue(
+				new \SMW\DIProperty( 'IPFS_CID' ),
+				new \SMWDIBlob( $normalizedCid )
+			);
+		}
+
+		if ( !empty( $data['title'] ) ) {
+			$semanticData->addPropertyObjectValue(
+				new \SMW\DIProperty( 'Release_title' ),
+				new \SMWDIBlob( $data['title'] )
+			);
+		}
+
+		if ( !empty( $data['release_type'] ) ) {
+			$semanticData->addPropertyObjectValue(
+				new \SMW\DIProperty( 'Release_type' ),
+				new \SMWDIBlob( $data['release_type'] )
+			);
+		}
+
+		if ( !empty( $data['file_type'] ) ) {
+			$semanticData->addPropertyObjectValue(
+				new \SMW\DIProperty( 'File_type' ),
+				new \SMWDIBlob( $data['file_type'] )
+			);
+		}
+
+		if ( !empty( $data['file_size'] ) ) {
+			$semanticData->addPropertyObjectValue(
+				new \SMW\DIProperty( 'File_size' ),
+				new \SMWDINumber( (float)(int)$data['file_size'] )
+			);
+		}
+
+		if ( !empty( $data['pinned_on'] ) ) {
+			$pinnedList = is_array( $data['pinned_on'] )
+				? implode( ', ', $data['pinned_on'] )
+				: (string)$data['pinned_on'];
+			$semanticData->addPropertyObjectValue(
+				new \SMW\DIProperty( 'Pinned_on' ),
+				new \SMWDIBlob( $pinnedList )
+			);
+		}
+
+		if ( !empty( $data['bittorrent_infohash'] ) ) {
+			$semanticData->addPropertyObjectValue(
+				new \SMW\DIProperty( 'BitTorrent_infohash' ),
+				new \SMWDIBlob( $data['bittorrent_infohash'] )
+			);
+		}
+
+		if ( !empty( $data['description'] ) ) {
+			$semanticData->addPropertyObjectValue(
+				new \SMW\DIProperty( 'Release_description' ),
+				new \SMWDIBlob( $data['description'] )
+			);
+		}
+
+		// Store semantic data in the ParserOutput for SMW to pick up
+		$parserData = \SMW\ParserData::makeFromCorePOD( $title, $output );
+		$parserData->getSemanticData()->importFrom( $semanticData );
+		$parserData->pushSemanticDataToParserOutput();
 	}
 
 	/**

--- a/extensions/PickiPediaReleases/src/SpecialReleases.php
+++ b/extensions/PickiPediaReleases/src/SpecialReleases.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Special page listing all releases
+ * Special page listing all releases, grouped by type
  *
  * @file
  * @ingroup Extensions
@@ -13,6 +13,14 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\SpecialPage\SpecialPage;
 
 class SpecialReleases extends SpecialPage {
+
+	/** @var array Type display config: key => [heading, order] */
+	private const TYPE_CONFIG = [
+		'video' => [ 'Videos', 1 ],
+		'record' => [ 'Records', 2 ],
+		'blue-railroad' => [ 'Blue Railroad', 3 ],
+		'other' => [ 'Other', 4 ],
+	];
 
 	public function __construct() {
 		parent::__construct( 'Releases' );
@@ -38,7 +46,17 @@ class SpecialReleases extends SpecialPage {
 		// Editable mid-section: MediaWiki:special-releases-mid
 		$this->addWikitextMessage( 'special-releases-mid' );
 
-		$out->addHTML( $this->renderTable( $releases ) );
+		// Group by release_type
+		$grouped = $this->groupByType( $releases );
+
+		foreach ( $grouped as $type => $items ) {
+			$heading = self::TYPE_CONFIG[$type][0] ?? ucfirst( $type );
+			$out->addHTML( Html::element( 'h2', [], $heading ) );
+			$out->addHTML( Html::element( 'p', [],
+				count( $items ) . ( count( $items ) === 1 ? ' release' : ' releases' )
+			) );
+			$out->addHTML( $this->renderTable( $items ) );
+		}
 
 		// Editable footer: MediaWiki:special-releases-footer
 		$this->addWikitextMessage( 'special-releases-footer' );
@@ -109,6 +127,7 @@ class SpecialReleases extends SpecialPage {
 				'title_obj' => $title,
 				'display_title' => $data['title'] ?? null,
 				'description' => $data['description'] ?? null,
+				'release_type' => $data['release_type'] ?? null,
 				'file_type' => $data['file_type'] ?? null,
 				'file_size' => isset( $data['file_size'] ) ? (int)$data['file_size'] : null,
 				'pinned_on' => $data['pinned_on'] ?? null,
@@ -117,6 +136,58 @@ class SpecialReleases extends SpecialPage {
 		}
 
 		return $releases;
+	}
+
+	/**
+	 * Group releases by type, inferring type for legacy releases.
+	 *
+	 * @param array $releases
+	 * @return array Keyed by type string, values are arrays of releases
+	 */
+	private function groupByType( array $releases ): array {
+		$grouped = [];
+
+		foreach ( $releases as $release ) {
+			$type = $release['release_type'] ?? $this->inferType( $release );
+			$grouped[$type][] = $release;
+		}
+
+		// Sort groups by configured order
+		uksort( $grouped, function ( $a, $b ) {
+			$orderA = self::TYPE_CONFIG[$a][1] ?? 99;
+			$orderB = self::TYPE_CONFIG[$b][1] ?? 99;
+			return $orderA <=> $orderB;
+		} );
+
+		return $grouped;
+	}
+
+	/**
+	 * Infer release type for legacy releases that lack release_type.
+	 *
+	 * @param array $release
+	 * @return string
+	 */
+	private function inferType( array $release ): string {
+		$fileType = $release['file_type'] ?? '';
+		$title = $release['display_title'] ?? '';
+
+		// Blue Railroad submissions have characteristic titles
+		if ( str_starts_with( $title, 'Blue Railroad Submission' ) ) {
+			return 'blue-railroad';
+		}
+
+		// Video MIME types
+		if ( str_starts_with( $fileType, 'video/' ) ) {
+			return 'video';
+		}
+
+		// Audio MIME types
+		if ( str_starts_with( $fileType, 'audio/' ) ) {
+			return 'record';
+		}
+
+		return 'other';
 	}
 
 	/**
@@ -133,6 +204,7 @@ class SpecialReleases extends SpecialPage {
 		$html .= Html::element( 'th', [], 'CID' );
 		$html .= Html::element( 'th', [], 'Title' );
 		$html .= Html::element( 'th', [], 'Type' );
+		$html .= Html::element( 'th', [], 'Size' );
 		$html .= Html::element( 'th', [], 'Pinned On' );
 		$html .= Html::element( 'th', [], 'References' );
 		$html .= Html::closeElement( 'tr' );
@@ -171,12 +243,19 @@ class SpecialReleases extends SpecialPage {
 		}
 		$html .= Html::element( 'td', [], $displayText );
 
-		// File type
-		$fileType = $release['file_type'] ?? '';
+		// File type (MIME)
+		$html .= Html::element( 'td', [], $release['file_type'] ?? '' );
+
+		// Size — separate sortable column
+		$sizeText = '';
+		$sortValue = 0;
 		if ( $release['file_size'] ) {
-			$fileType .= ' · ' . $this->formatFileSize( $release['file_size'] );
+			$sizeText = $this->formatFileSize( $release['file_size'] );
+			$sortValue = $release['file_size'];
 		}
-		$html .= Html::element( 'td', [], $fileType );
+		$html .= Html::element( 'td', [
+			'data-sort-value' => $sortValue,
+		], $sizeText );
 
 		// Pinned on
 		$pinnedOn = '';


### PR DESCRIPTION
## Summary
- **Special:Releases** now groups releases into four tables (Videos, Records, Blue Railroad, Other) with Size as its own sortable column
- **SMW properties** emitted from Release pages: Release title, Release type, File type, File size, IPFS CID, Pinned on, BitTorrent infohash, Release description — enables `#ask` queries from any wiki page
- **Type-based categories** added (Video_Releases, Record_Releases, etc.)
- Legacy releases without `release_type` are inferred from MIME type and title patterns

## Test plan
- [ ] Deploy Docker image and visit Special:Releases — verify four grouped tables render
- [ ] Check Size column sorts correctly
- [ ] Visit Special:Browse on a Release page to verify SMW properties appear
- [ ] Test `{{#ask: [[Release type::video]] |?Release title |?File size}}` on a wiki page
- [ ] Run `php maintenance/runJobs.php` to trigger SMW re-indexing of existing pages