### PR TITLE
Fix SMW: write to store directly for custom content types

### DIFF
--- a/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
@@ -225,10 +225,10 @@ YAML;
 			$addText( 'Release_description', $data['description'] );
 		}
 
-		// Store semantic data in the ParserOutput for SMW to pick up
-		$parserData = new \SMW\ParserData( $title, $output );
-		$parserData->getSemanticData()->importFrom( $semanticData );
-		$parserData->pushSemanticDataToParserOutput();
+		// Write directly to SMW store — custom content handlers bypass
+		// SMW's parser hooks, so the ParserOutput pipeline doesn't work.
+		$store = \SMW\StoreFactory::getStore();
+		$store->updateData( $semanticData );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Custom content handlers bypass SMW's parser hooks entirely, so writing to ParserOutput via `ParserData` never reaches SMW's data update pipeline
- Switch to `StoreFactory::getStore()->updateData()` which writes semantic data directly to SMW's database
- This is the correct pattern for non-wikitext content models

## Test plan
- [ ] Deploy and purge a Release page
- [ ] Check `Special:Browse` — properties should now appear
- [ ] Run rebuildData to populate all pages