### PR TITLE
Prefer finalize token for draft preview checks

### DIFF
--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -1083,7 +1083,8 @@
 		}
 
 		var deliveryKidUrl = mw.config.get( 'wgDeliveryKidUrl' );
-		var token = mw.config.get( 'wgUploadToken' );
+		// Prefer finalize token (release group) over upload token (uploader only)
+		var token = mw.config.get( 'wgFinalizeToken' ) || mw.config.get( 'wgUploadToken' );
 		var user = mw.config.get( 'wgUploadUser' );
 		var timestamp = mw.config.get( 'wgUploadTimestamp' );
 		var gatewayUrl = mw.config.get( 'wgIpfsGatewayUrl' ) || 'https://ipfs.delivery-kid.cryptograss.live';


### PR DESCRIPTION
## Summary
- JS now sends `wgFinalizeToken` (if available) instead of `wgUploadToken` when checking draft preview status
- Allows finalize-release users to preview drafts uploaded by other users
- Companion to cryptograss/maybelle-config#81

## Test plan
- [ ] Deploy alongside delivery-kid update
- [ ] Log in as release group user, view Sky's draft — preview should load