### PR TITLE
Fix Release page diffs: extend TextContent

### DIFF
--- a/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
@@ -102,6 +102,28 @@ YAML;
 		// Get optional YAML metadata
 		$data = $content->getData();
 
+		// Show banner for deleted or unpinned releases
+		$isDeleted = !empty( $data['delete'] );
+		$isUnpinned = !empty( $data['unpin'] );
+		$pinnedOn = $data['pinned_on'] ?? null;
+		$hasActivePins = !empty( $pinnedOn );
+
+		if ( $isDeleted && !$hasActivePins ) {
+			$html .= Html::rawElement( 'div', [
+				'class' => 'release-deleted-banner',
+				'style' => 'background:#fee; border:2px solid #c00; padding:1em; margin-bottom:1em; border-radius:4px;',
+			], Html::element( 'strong', [ 'style' => 'color:#c00;' ],
+				'This release has been deleted and is no longer pinned or distributed.'
+			) );
+		} elseif ( $isUnpinned && !$hasActivePins ) {
+			$html .= Html::rawElement( 'div', [
+				'class' => 'release-unpinned-banner',
+				'style' => 'background:#fee; border:2px solid #c00; padding:1em; margin-bottom:1em; border-radius:4px;',
+			], Html::element( 'strong', [ 'style' => 'color:#c00;' ],
+				'This release has been unpinned and is no longer distributed.'
+			) );
+		}
+
 		// Determine if this release is a video:
 		// 1. Explicit file_type in YAML
 		// 2. Inferred from backlinks (pages using HLSVideo template link here)

--- a/extensions/PickiPediaReleases/src/SpecialReleases.php
+++ b/extensions/PickiPediaReleases/src/SpecialReleases.php
@@ -122,6 +122,16 @@ class SpecialReleases extends SpecialPage {
 				->caller( __METHOD__ )
 				->fetchField();
 
+			// Skip deleted/unpinned releases that have no active pins
+			$isDeleted = !empty( $data['delete'] );
+			$isUnpinned = !empty( $data['unpin'] );
+			$pinnedOn = $data['pinned_on'] ?? null;
+			$hasActivePins = !empty( $pinnedOn );
+
+			if ( ( $isDeleted || $isUnpinned ) && !$hasActivePins ) {
+				continue;
+			}
+
 			$releases[] = [
 				'page_title' => $row->page_title,
 				'title_obj' => $title,
@@ -130,7 +140,7 @@ class SpecialReleases extends SpecialPage {
 				'release_type' => $data['release_type'] ?? null,
 				'file_type' => $data['file_type'] ?? null,
 				'file_size' => isset( $data['file_size'] ) ? (int)$data['file_size'] : null,
-				'pinned_on' => $data['pinned_on'] ?? null,
+				'pinned_on' => $pinnedOn,
 				'backlinks' => (int)$backlinkCount,
 			];
 		}


### PR DESCRIPTION
## Summary
Release page diffs crash with `ParameterTypeException: must be a TextContent|null`. `ReleaseContent` extended `AbstractContent` but MediaWiki's diff engine requires `TextContent`. Since release-yaml is plain text, this is the correct base class anyway.

Also removes redundant method overrides (`getNativeData`, `getSize`, `serialize`, `getWikitextForTransclusion`) that `TextContent` already provides.

## Test plan
- [ ] Deploy and view a Release page diff — should render without error
- [ ] Release page normal view still works
- [ ] Raw YAML view still works