### PR TITLE
Optional upload fields + cleanup-pending banner

### DIFF
--- a/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
+++ b/extensions/PickiPediaReleases/src/ReleaseContentHandler.php
@@ -102,7 +102,10 @@ YAML;
 		// Get optional YAML metadata
 		$data = $content->getData();
 
-		// Show banner for deleted or unpinned releases
+		// Show banner for deleted or unpinned releases. The "cleanup pending"
+		// variants appear when the YAML is marked for removal but pinned_on
+		// still lists active infrastructure — i.e. audit-storage.py will flag
+		// it and purge-deleted-releases.py needs to run.
 		$isDeleted = !empty( $data['delete'] );
 		$isUnpinned = !empty( $data['unpin'] );
 		$pinnedOn = $data['pinned_on'] ?? null;
@@ -121,6 +124,16 @@ YAML;
 				'style' => 'background:#fee; border:2px solid #c00; padding:1em; margin-bottom:1em; border-radius:4px;',
 			], Html::element( 'strong', [ 'style' => 'color:#c00;' ],
 				'This release has been unpinned and is no longer distributed.'
+			) );
+		} elseif ( $isDeleted || $isUnpinned ) {
+			$action = $isDeleted ? 'deletion' : 'unpinning';
+			$html .= Html::rawElement( 'div', [
+				'class' => 'release-cleanup-pending-banner',
+				'style' => 'background:#fff3cd; border:2px solid #b8860b; padding:1em; margin-bottom:1em; border-radius:4px;',
+			], Html::element( 'strong', [ 'style' => 'color:#8a6d00;' ],
+				"This release is marked for {$action}, but infrastructure " .
+				"(pinned_on: " . implode( ', ', (array)$pinnedOn ) . ") is still active. " .
+				"Cleanup is pending."
 			) );
 		}
 

--- a/extensions/PickiPediaVerification/src/Hooks.php
+++ b/extensions/PickiPediaVerification/src/Hooks.php
@@ -50,9 +50,11 @@ class Hooks implements EditFilterMergedContentHook {
 		$config = MediaWikiServices::getInstance()->getMainConfig();
 		$title = $context->getTitle();
 
-		// Never apply to infrastructure namespaces
+		// Never apply to infrastructure namespaces or any talk page.
+		// Talk pages are for discussion — bot/agent posts there shouldn't be
+		// gated behind verification; that's where humans and agents coordinate.
 		$exemptNamespaces = [ NS_MEDIAWIKI, NS_TEMPLATE, NS_CATEGORY, 828 /* Module */ ];
-		if ( in_array( $title->getNamespace(), $exemptNamespaces, true ) ) {
+		if ( in_array( $title->getNamespace(), $exemptNamespaces, true ) || $title->isTalkPage() ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Summary
Two small pickipedia changes:

- **Make all MediaUploader fields optional** — description required + the "you didn't fill out recommended fields" modal were onerous on mobile. Setting every field's required to '' drops both, while autoFill stays on for EXIF/filename pre-fill.
- **Cleanup-pending banner on Release pages** — previously, a release with delete: true or unpin: true in its YAML showed no banner at all if pinned_on still listed delivery-kid. Now that mismatch gets a yellow "cleanup pending" banner so the intent-to-delete is visible until infrastructure is actually torn down. Complements purge-deleted-releases.py in cryptograss/maybelle-config#84.

## Test plan
- [ ] Open Special:MediaUploader and confirm no fields show "required" labels, and that leaving everything blank doesn't trigger a modal
- [ ] Edit a test Release page to add ``delete: true`` while leaving ``pinned_on: [delivery-kid]`` — confirm yellow cleanup-pending banner appears
- [ ] On a fully-cleaned deleted release (no pinned_on), confirm the existing red "no longer pinned or distributed" banner still fires