### PR TITLE
ReleaseDraft modal: poll finalize_log instead of lying about completion

### DIFF
--- a/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
+++ b/extensions/PickiPediaReleases/resources/ext.pickipediaReleases.releaseDraft.js
@@ -762,13 +762,21 @@
 			appendLog( 'CID: ' + ( data.cid || 'unknown' ) );
 			showFinalizeResult( data );
 		} else if ( event === 'transcoding-submitted' ) {
-			setProgress( 100 );
-			setActiveStage( 'complete' );
-			setStatus( 'Cloud transcoding submitted!', 'success' );
-			appendLog( 'Source CID: ' + ( data.sourceCid || 'unknown' ) );
-			appendLog( 'Job ID: ' + ( data.jobId || 'unknown' ) );
+			// Don't lie: Coconut just *started*, this is not "complete".
+			// The SSE closes here because the actual work — transcode →
+			// webhook → HLS pin → finalize state — happens asynchronously
+			// on delivery-kid over the next 1-3 minutes. Switch the modal
+			// into "waiting for webhook" mode: keep it open, poll
+			// /draft-content for finalize_log updates, narrate stages as
+			// they fire on the server side.
+			setProgress( 60 );
+			setActiveStage( 'transcoding' );
+			setStatus( 'Cloud transcoding in progress (waiting for Coconut)…', '' );
+			appendLog( 'Source: ' + ( data.sourceCid || 'staging' ) );
+			appendLog( 'Coconut job: ' + ( data.coconutJobId || data.jobId || 'unknown' ) );
 			appendLog( data.message || '' );
 			showTranscodingResult( data );
+			startFinalizePolling();
 		} else if ( event === 'error' ) {
 			setStageError();
 			showFinalizeError( 'Error: ' + ( data.message || 'Unknown error' ) );
@@ -823,6 +831,136 @@
 			active.classList.remove( 'rd-stage-active' );
 			active.classList.add( 'rd-stage-error' );
 		}
+	}
+
+	// === Webhook-driven finalize polling ===
+	//
+	// For the slow Coconut path the SSE closes after 'transcoding-submitted',
+	// minutes before the actual work completes server-side. We poll
+	// /draft-content/{draft_id} to watch the finalize_log entries written
+	// by routes/coconut.py _update_draft_finalize as the webhook processes
+	// the job, and update the modal's stage chips + log + status text
+	// accordingly. On terminal state we hand off to showFinalizeResult /
+	// showFinalizeError just as the streaming path would.
+	var finalizePollTimer = null;
+	var finalizePollLastLogLen = 0;
+	var finalizePollMaxMs = 15 * 60 * 1000; // 15 min hard cap; Coconut usually finishes in 1-3
+	var finalizePollStartedAt = 0;
+
+	function finalizeStageFromLogEntry( entry ) {
+		// Map server-side finalize_log entry.stage onto the modal's
+		// stage chips. Server emits webhook/pin/complete from the
+		// webhook handler; finalize_sse_generator emits prepare/transcode/
+		// tag stages earlier in the flow.
+		var s = ( entry && entry.stage ) ? entry.stage.toLowerCase() : '';
+		if ( s === 'prepare' || s === 'preparing' ) { return 'preparing'; }
+		if ( s === 'transcode' || s === 'transcoding' || s === 'webhook' ) {
+			return 'transcoding';
+		}
+		if ( s === 'tag' || s === 'tagging' ) { return 'tagging'; }
+		if ( s === 'pin' || s === 'pinning' ) { return 'pinning'; }
+		if ( s === 'complete' ) { return 'complete'; }
+		return null;
+	}
+
+	function stopFinalizePolling() {
+		if ( finalizePollTimer ) {
+			clearInterval( finalizePollTimer );
+			finalizePollTimer = null;
+		}
+	}
+
+	function startFinalizePolling() {
+		var draftId = ( draftData && draftData.draft_id ) || '';
+		var deliveryKidUrl = mw.config.get( 'wgDeliveryKidUrl' );
+		var uploadToken = mw.config.get( 'wgFinalizeToken' ) ||
+			mw.config.get( 'wgUploadToken' );
+		if ( !draftId || !deliveryKidUrl || !uploadToken ) {
+			appendLog( '(cannot poll finalize state — missing config)' );
+			return;
+		}
+		var headers = {
+			'X-Upload-Token': uploadToken,
+			'X-Upload-User': mw.config.get( 'wgUploadUser' ),
+			'X-Upload-Timestamp': String( mw.config.get( 'wgUploadTimestamp' ) )
+		};
+
+		stopFinalizePolling();
+		// Don't carry log-length state across separate finalize runs.
+		finalizePollLastLogLen = 0;
+		finalizePollStartedAt = Date.now();
+
+		function poll() {
+			if ( Date.now() - finalizePollStartedAt > finalizePollMaxMs ) {
+				stopFinalizePolling();
+				setStatus(
+					'Stopped waiting for Coconut after 15 min — check delivery-kid logs.',
+					'error'
+				);
+				return;
+			}
+
+			fetch( deliveryKidUrl + '/draft-content/' +
+					encodeURIComponent( draftId ),
+				{ headers: headers }
+			).then( function ( resp ) {
+				if ( !resp.ok ) { return null; }
+				return resp.json();
+			} ).then( function ( state ) {
+				if ( !state ) { return; }
+
+				// Replay newly-appended finalize_log entries into the
+				// modal: stage chip + status text + log line each.
+				var log = state.finalize_log || [];
+				for ( var i = finalizePollLastLogLen; i < log.length; i++ ) {
+					var entry = log[ i ];
+					var msg = entry.message || '';
+					var stagePrefix = entry.stage ?
+						'[' + entry.stage + '] ' : '';
+					appendLog( stagePrefix + msg );
+					var modalStage = finalizeStageFromLogEntry( entry );
+					if ( modalStage ) {
+						setActiveStage( modalStage );
+					}
+					if ( msg && !entry.error ) {
+						setStatus( msg, '' );
+					}
+				}
+				finalizePollLastLogLen = log.length;
+
+				// Terminal-state handoff.
+				if ( state.status === 'finalized' && state.final_cid ) {
+					stopFinalizePolling();
+					setProgress( 100 );
+					setActiveStage( 'complete' );
+					var gw = ( state.preview_gateway_url ||
+						deliveryKidUrl.replace( '://delivery-kid', '://ipfs.delivery-kid' ) +
+						'/ipfs/' + state.final_cid );
+					showFinalizeResult( {
+						cid: state.final_cid,
+						gateway_url: gw
+					} );
+				} else if ( state.status === 'finalize_failed' ) {
+					stopFinalizePolling();
+					setStageError();
+					var errMsg = 'Finalize failed';
+					if ( log.length ) {
+						var last = log[ log.length - 1 ];
+						if ( last && last.error ) { errMsg = last.error; }
+						else if ( last && last.message ) { errMsg = last.message; }
+					}
+					showFinalizeError( errMsg );
+				}
+			} ).catch( function () {
+				// Silent retry on next tick — transient blips shouldn't
+				// pollute the modal log.
+			} );
+		}
+
+		// Kick off immediately so the user gets the first stage update
+		// without waiting a full poll interval.
+		poll();
+		finalizePollTimer = setInterval( poll, 3000 );
 	}
 
 	function setProgress( pct ) {


### PR DESCRIPTION
## The bug

The finalize modal on the ReleaseDraft page receives an SSE \`transcoding-submitted\` event from delivery-kid the moment Coconut accepts the job — and immediately calls \`setActiveStage('complete')\` + \`setStatus('Cloud transcoding submitted!', 'success')\`. That's why all the stage chips (Preparing → Transcoding → Tagging → Pinning → Complete) flash green at once and the success banner appears even though Coconut is just *starting* a 1-3 minute transcode.

After the SSE closes, the modal has no way to learn that the webhook eventually fired, the HLS was pinned, and the draft was actually finalized. So the user sees a fake "done" state, doesn't see real progress, and doesn't get notified when things actually finish (or fail).

## The fix

When \`transcoding-submitted\` fires:

1. Set stage to \`transcoding\` (honest — Coconut is transcoding, not done)
2. Set progress to 60% (post-submit, mid-process)
3. Set status to *"Cloud transcoding in progress (waiting for Coconut)…"*
4. Save the draft (existing \`showTranscodingResult\` behavior)
5. **Start polling \`/draft-content/{id}\`** every 3s

The poll loop reads the same \`finalize_log\` field the diagnostics panel reads. Whenever delivery-kid's webhook handler (cryptograss/maybelle-config #95 / #96) appends \`webhook\` / \`pin\` / \`complete\` stage entries, the modal:

- Appends the log message to its own progress log
- Advances the stage chip via a stage-name mapping (\`webhook\` → \`transcoding\`, \`pin\` → \`pinning\`, etc.)
- Updates the status text with the latest message

When \`state.status\` flips to \`finalized\` + \`state.final_cid\` is set, the loop stops and hands off to the existing \`showFinalizeResult({cid, gateway_url})\` path — same code path the streaming success used to take, including the YAML edit and Release-page link.

When \`state.status\` flips to \`finalize_failed\`, hand off to \`showFinalizeError\` with the last log entry's error or message.

Hard cap at 15 minutes so a failed Coconut callback doesn't poll forever; user gets a clean *"Stopped waiting for Coconut after 15 min — check delivery-kid logs"* instead of forever-spinning.

## Pairs with

- maybelle-config #95: finalize webhook updates draft.json (status, final_cid, finalize_log)
- maybelle-config #96: webhook also writes the ReleaseDraft wiki YAML so the Blue Railroad Imports bot can promote it

With this PR + those two, the full slow-Coconut finalize path narrates correctly end-to-end:

1. SSE: prepare → transcode-submitted (modal goes into polling mode)
2. Webhook callback ~2 min later: appends webhook/pin/complete to finalize_log
3. Modal polls, updates stages and log in real time
4. \`state.status = finalized\` → showFinalizeResult fires, Release link appears
5. Blue Railroad bot creates Release:{cid} on next cron run

## Test plan

- [ ] Deploy pickipedia (with the maybelle-config deploy already done so the server side is feeding real \`finalize_log\` stages)
- [ ] Re-finalize the terrapin draft (or any in-flight Coconut-submitted finalize)
- [ ] Modal stays open and narrates: chip moves from transcoding → pinning → complete as the webhook progresses
- [ ] Log lines show \`[webhook] Coconut callback received\`, \`[pin] HLS pinned to IPFS as Qm…\`, \`[complete] Finalize complete\` as they're appended on the server
- [ ] On \`finalized\`, status flips to "Pinned to IPFS! CID: Qm…" and a Release page link appears
- [ ] If Coconut fails / hangs > 15 min, the timeout message appears cleanly instead of polling forever